### PR TITLE
feat: add /edit-pack command to update pack metadata

### DIFF
--- a/src/commands/edit-pack.command.ts
+++ b/src/commands/edit-pack.command.ts
@@ -1,0 +1,131 @@
+import { ComponentType, MessageFlags, TextInputStyle } from 'discord-api-types/v10';
+import { ComponentInLabelData, TextInputComponentData } from 'discord.js';
+import { editPackOptions } from '../options/edit-pack.options.js';
+import { packNameOptionMeta } from '../options/metadata/pack-name.option-meta.js';
+import { BotChatInputCommand, BotChatInputCommandName, BotModalId } from '../types/bot-interaction.js';
+import { EditPackCommandOptionName } from '../types/localization.js';
+import { getPackNameAutocompleteHandler } from '../utils/autocomplete/pack-name.autocomplete.js';
+import { getLocalizedObject } from '../utils/get-localized-object.js';
+import { getPackNsfwEmoji } from '../utils/get-pack-nsfw-emoji.js';
+import { getPackVisibilityEmoji } from '../utils/get-pack-visibility-emoji.js';
+import { interactionReply } from '../utils/interaction-reply.js';
+import { updateOrCreateUser } from '../utils/messaging.js';
+import {
+  EditPackModalBooleanOption,
+  EditPackModalCustomIds,
+  editPackModalHandler,
+} from './modal-handlers/edit-pack.modal-handler.js';
+
+export const editPackCommand: BotChatInputCommand = {
+  name: BotChatInputCommandName.EDIT_PACK,
+  getDefinition: (t) => {
+    if (!t) throw new Error('Missing translation function');
+    return {
+      ...getLocalizedObject('description', (lng) => t('commands.edit-pack.description', { lng })),
+      ...getLocalizedObject('name', (lng) => t('commands.edit-pack.name', { lng })),
+      options: editPackOptions(t),
+    };
+  },
+  autocomplete: {
+    [EditPackCommandOptionName.NAME]: getPackNameAutocompleteHandler({ ownedOnly: true }),
+  },
+  async handle(interaction, context) {
+    const { t, db } = context;
+    const user = await updateOrCreateUser(context, interaction);
+    if (user.readOnly) {
+      await interactionReply(context, interaction, {
+        content: t('commands.global.responses.noPermission'),
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const id = interaction.options.getString(EditPackCommandOptionName.NAME, true);
+    const pack = await db.pack.findUnique({
+      where: { id, deletedAt: null, createdBy: user.id },
+    });
+
+    if (!pack) {
+      await interactionReply(context, interaction, {
+        content: t('commands.edit-pack.responses.packNotFound'),
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.showModal({
+      customId: `${BotModalId.EDIT_PACK}:${pack.id}`,
+      title: t('commands.edit-pack.components.editPackModalTitle', { name: pack.name }),
+      components: [
+        {
+          type: ComponentType.Label,
+          label: t('commands.edit-pack.components.nameLabel'),
+          description: t('commands.edit-pack.components.nameDescription'),
+          component: {
+            type: ComponentType.TextInput,
+            customId: EditPackModalCustomIds.NAME_INPUT,
+            style: TextInputStyle.Short,
+            minLength: packNameOptionMeta.min_length,
+            maxLength: packNameOptionMeta.max_length,
+            required: true,
+            value: pack.name,
+          } as TextInputComponentData,
+        },
+        {
+          type: ComponentType.Label,
+          label: t('commands.edit-pack.components.publicChoiceLabel'),
+          description: t('commands.edit-pack.components.publicChoiceDescription'),
+          component: {
+            type: ComponentType.RadioGroup,
+            customId: EditPackModalCustomIds.PUBLIC_INPUT,
+            options: [
+              {
+                value: EditPackModalBooleanOption.TRUE,
+                label: `${getPackVisibilityEmoji({ public: true })} ${t('commands.edit-pack.components.publicTrueLabel')}`,
+                description: t('commands.edit-pack.components.publicTrueDescription'),
+                default: pack.public,
+              },
+              {
+                value: EditPackModalBooleanOption.FALSE,
+                label: `${getPackVisibilityEmoji({ public: false })} ${t('commands.edit-pack.components.publicFalseLabel')}`,
+                description: t('commands.edit-pack.components.publicFalseDescription'),
+                default: !pack.public,
+              },
+            ],
+          } as unknown as ComponentInLabelData,
+        },
+        {
+          type: ComponentType.Label,
+          label: t('commands.edit-pack.components.nsfwChoiceLabel'),
+          description: t('commands.edit-pack.components.nsfwChoiceDescription'),
+          component: {
+            type: ComponentType.RadioGroup,
+            customId: EditPackModalCustomIds.NSFW_INPUT,
+            options: [
+              {
+                value: EditPackModalBooleanOption.FALSE,
+                label: t('commands.edit-pack.components.nsfwFalseLabel'),
+                description: t('commands.edit-pack.components.nsfwFalseDescription', {
+                  command: `/${t('commands.sticker.name')}`,
+                }),
+                default: !pack.nsfw,
+              },
+              {
+                value: EditPackModalBooleanOption.TRUE,
+                label: t('commands.edit-pack.components.nsfwTrueLabel')
+                  + getPackNsfwEmoji({ nsfw: true }),
+                description: t('commands.edit-pack.components.nsfwTrueDescription', {
+                  command: `/${t('commands.nsfw-sticker.name')}`,
+                }),
+                default: pack.nsfw,
+              },
+            ],
+          } as unknown as ComponentInLabelData,
+        },
+      ],
+    });
+  },
+  modal: {
+    [BotModalId.EDIT_PACK]: editPackModalHandler,
+  },
+};

--- a/src/commands/modal-handlers/edit-pack.modal-handler.ts
+++ b/src/commands/modal-handlers/edit-pack.modal-handler.ts
@@ -1,0 +1,122 @@
+import { MessageFlags } from 'discord-api-types/v10';
+import { EmojiCharacters } from '../../constants/emoji-characters.js';
+import {
+  packNameInvalidPattern,
+  packNameOptionMeta,
+} from '../../options/metadata/pack-name.option-meta.js';
+import { ModalHandler } from '../../types/bot-interaction.js';
+import { getPackVisibilityEmoji } from '../../utils/get-pack-visibility-emoji.js';
+import { interactionReply } from '../../utils/interaction-reply.js';
+import { collectModalSubmittedData, updateOrCreateUser } from '../../utils/messaging.js';
+import { PackSnapshot, postPackToFeed } from '../../utils/post-pack-to-feed.js';
+
+export enum EditPackModalCustomIds {
+  NAME_INPUT = 'nameInput',
+  PUBLIC_INPUT = 'publicInput',
+  NSFW_INPUT = 'nsfwInput',
+}
+
+export enum EditPackModalBooleanOption {
+  TRUE = 'true',
+  FALSE = 'false',
+}
+
+export const editPackModalHandler: ModalHandler = async (interaction, context, resourceId) => {
+  const { t, db } = context;
+  const user = await updateOrCreateUser(context, interaction);
+  if (user.readOnly) {
+    await interactionReply(context, interaction, {
+      content: t('commands.global.responses.noPermission'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  let pack = resourceId ? await db.pack.findUnique({
+    where: { id: resourceId, deletedAt: null, createdBy: user.id },
+  }) : null;
+
+  if (!pack) {
+    await interactionReply(context, interaction, {
+      content: t('commands.edit-pack.responses.packNotFound'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+  const packSnapshot: PackSnapshot = {
+    name: pack.name,
+    public: pack.public,
+    nsfw: pack.nsfw,
+  };
+
+  const { data } = collectModalSubmittedData(interaction, EditPackModalCustomIds);
+
+  const packName = data[EditPackModalCustomIds.NAME_INPUT];
+  if (packName !== pack.name) {
+    if (packName === null || packName.length < packNameOptionMeta.min_length) {
+      await interactionReply(context, interaction, {
+        content: t('commands.edit-pack.responses.nameTooShort'),
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    if (packName.length > packNameOptionMeta.max_length) {
+      await interactionReply(context, interaction, {
+        content: t('commands.edit-pack.responses.nameTooLong'),
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    const invalidChars = new Set(packName.match(packNameInvalidPattern));
+    if (invalidChars.size > 0) {
+      await interactionReply(context, interaction, {
+        content: t('commands.edit-pack.responses.invalidName', {
+          chars: '```\n' + Array.from(invalidChars).join('') + '\n```',
+        }),
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    const otherPacksWithSameNameCount = await db.pack.count({
+      where: {
+        AND: [
+          { name: packName, deletedAt: null },
+          { NOT: { id: pack.id } },
+        ],
+      },
+    });
+    if (otherPacksWithSameNameCount !== 0) {
+      await interactionReply(context, interaction, {
+        content: t('commands.edit-pack.responses.duplicateName'),
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+  }
+
+  pack = await db.pack.update({
+    where: { id: pack.id },
+    data: {
+      name: packName,
+      public: data[EditPackModalCustomIds.PUBLIC_INPUT] === EditPackModalBooleanOption.TRUE,
+      nsfw: data[EditPackModalCustomIds.NSFW_INPUT] === EditPackModalBooleanOption.TRUE,
+    },
+  });
+
+  await interactionReply(context, interaction, {
+    content: [
+      EmojiCharacters.GREEN_CHECK,
+      getPackVisibilityEmoji(pack),
+      t('commands.edit-pack.responses.updated', { name: `\`${pack.name}\`` }),
+    ].join(' '),
+    flags: MessageFlags.Ephemeral,
+  });
+
+  await postPackToFeed({
+    context,
+    interaction,
+    pack,
+    action: 'edit',
+    snapshot: packSnapshot,
+  });
+};

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -194,6 +194,41 @@
         }
       }
     },
+    "edit-pack": {
+      "name": "edit-pack",
+      "description": "Update the name, visibility, or content rating of an existing sticker pack",
+      "responses": {
+        "packNotFound": "The specified pack could not be found",
+        "nameTooShort": "The provided sticker pack name is too short (minimum {{min}} characters)",
+        "nameTooLong": "The provided sticker pack name is too long (maximum {{max}} characters)",
+        "invalidName": "The provided sticker pack name contains the following  invalid character(s): {{chars}}",
+        "duplicateName": "A sticker pack with the same name already exists, please choose a different one",
+        "updated": "The pack {{name}} has been updated successfully"
+      },
+      "components": {
+        "editPackModalTitle": "Edit pack {{name}}",
+        "nameLabel": "Pack name",
+        "nameDescription": "Enter a unique name for the sticker pack. Two packs cannot have the same name within the app.",
+        "publicChoiceLabel": "Pack visibility",
+        "publicChoiceDescription": "Determines who will be able to see and use the stickers in the pack.",
+        "publicTrueLabel": "Public",
+        "publicTrueDescription": "The pack will be visible usable by everyone",
+        "publicFalseLabel": "Private",
+        "publicFalseDescription": "The pack will only be visible to and usable by you",
+        "nsfwChoiceLabel": "Pack content rating",
+        "nsfwChoiceDescription": "Determines where and how the stickers in this pack will be usable.",
+        "nsfwTrueLabel": "Age-restricted (NSFW)",
+        "nsfwTrueDescription": "Stickers will only be usable in age-restricted channels and DMs via {{command}}",
+        "nsfwFalseLabel": "Safe for all audiences",
+        "nsfwFalseDescription": "Stickers will be usable in any channel and DMs via {{command}}"
+      },
+      "options": {
+        "name": {
+          "name": "name",
+          "description": "Name of the pack you want to edit"
+        }
+      }
+    },
     "delete-sticker": {
       "name": "delete-sticker",
       "description": "Delete an existing sticker",

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -45,7 +45,7 @@
       "responses": {
         "nameTooShort": "The provided sticker pack name is too short (minimum {{min}} characters)",
         "nameTooLong": "The provided sticker pack name is too long (maximum {{max}} characters)",
-        "invalidName": "The provided sticker pack name contains the following  invalid character(s): {{chars}}",
+        "invalidName": "The provided sticker pack name contains the following invalid character(s): {{chars}}",
         "duplicateName": "A sticker pack with the same name already exists, please choose a different one",
         "tooManyPacks": "You can only create up to {{maxPacks}} sticker packs. Please delete an existing pack before creating a new one.",
         "createdPublic": "New **public** sticker pack created with name {{name}}",
@@ -108,7 +108,7 @@
         "invalidPack": "The selected pack could not be found",
         "nameTooShort": "The provided sticker name is too short (minimum {{min}} characters)",
         "nameTooLong": "The provided sticker name is too long (maximum {{max}} characters)",
-        "invalidName": "The provided sticker name contains the following  invalid character(s): {{chars}}",
+        "invalidName": "The provided sticker name contains the following invalid character(s): {{chars}}",
         "duplicateName": "A sticker with the same name already exists in this pack, please choose a different one",
         "missingFile": "You must upload a file for the sticker",
         "invalidUrl": "The provided URL is invalid",
@@ -201,7 +201,7 @@
         "packNotFound": "The specified pack could not be found",
         "nameTooShort": "The provided sticker pack name is too short (minimum {{min}} characters)",
         "nameTooLong": "The provided sticker pack name is too long (maximum {{max}} characters)",
-        "invalidName": "The provided sticker pack name contains the following  invalid character(s): {{chars}}",
+        "invalidName": "The provided sticker pack name contains the following invalid character(s): {{chars}}",
         "duplicateName": "A sticker pack with the same name already exists, please choose a different one",
         "updated": "The pack {{name}} has been updated successfully"
       },

--- a/src/options/edit-pack.options.ts
+++ b/src/options/edit-pack.options.ts
@@ -1,0 +1,15 @@
+import { APIApplicationCommandOption } from 'discord-api-types/v10';
+import { TFunction } from 'i18next';
+import { BotChatInputCommandName } from '../types/bot-interaction.js';
+import { EditPackCommandOptionName } from '../types/localization.js';
+import { getCommonOptionMeta } from '../utils/get-common-option-meta.js';
+import { packNameOptionMeta } from './metadata/pack-name.option-meta.js';
+
+export const editPackOptions = (t: TFunction): APIApplicationCommandOption[] => [
+  {
+    ...getCommonOptionMeta(t, BotChatInputCommandName.EDIT_PACK, EditPackCommandOptionName.NAME),
+    required: true,
+    autocomplete: true,
+    ...packNameOptionMeta,
+  },
+];

--- a/src/types/bot-interaction.ts
+++ b/src/types/bot-interaction.ts
@@ -24,6 +24,7 @@ export const enum BotChatInputCommandName {
   EDIT_STICKER = 'edit-sticker',
   DELETE_STICKER = 'delete-sticker',
   DELETE_PACK = 'delete-pack',
+  EDIT_PACK = 'edit-pack',
 }
 
 export const enum BotMessageContextMenuCommandName {
@@ -37,6 +38,7 @@ export const enum BotModalId {
   DELETE_STICKER = 'deleteStickerModal',
   CREATE_PACK = 'createPackModal',
   DELETE_PACK = 'deletePackModal',
+  EDIT_PACK = 'editPackModal',
 }
 
 export const enum BotMessageComponentCustomId {

--- a/src/types/localization.ts
+++ b/src/types/localization.ts
@@ -34,6 +34,10 @@ export const enum DeletePackCommandOptionName {
   NAME = 'name',
 }
 
+export const enum EditPackCommandOptionName {
+  NAME = 'name',
+}
+
 interface CommandOptionsMap {
   [BotChatInputCommandName.STICKER]: StickerCommandOptionName,
   [BotChatInputCommandName.NSFW_STICKER]: StickerCommandOptionName,
@@ -44,6 +48,7 @@ interface CommandOptionsMap {
   [BotChatInputCommandName.EDIT_STICKER]: EditStickerCommandOptionName,
   [BotChatInputCommandName.DELETE_STICKER]: DeleteStickerCommandOptionName,
   [BotChatInputCommandName.DELETE_PACK]: DeletePackCommandOptionName,
+  [BotChatInputCommandName.EDIT_PACK]: EditPackCommandOptionName,
 }
 
 export const enum GlobalCommandResponse {
@@ -117,6 +122,15 @@ export const enum DeletePackCommandResponse {
   deleted = 'deleted',
 }
 
+export const enum EditPackCommandResponse {
+  packNotFound = 'packNotFound',
+  nameTooShort = 'nameTooShort',
+  nameTooLong = 'nameTooLong',
+  invalidName = 'invalidName',
+  duplicateName = 'duplicateName',
+  updated = 'updated',
+}
+
 interface CommandResponsesMap {
   global: GlobalCommandResponse,
   [BotChatInputCommandName.STICKER]: StickerCommandResponse,
@@ -127,6 +141,7 @@ interface CommandResponsesMap {
   [BotChatInputCommandName.EDIT_STICKER]: EditStickerCommandResponse,
   [BotChatInputCommandName.DELETE_STICKER]: DeleteStickerCommandResponse,
   [BotChatInputCommandName.DELETE_PACK]: DeletePackCommandResponse,
+  [BotChatInputCommandName.EDIT_PACK]: EditPackCommandResponse,
 }
 
 interface ComponentsMap {
@@ -172,6 +187,23 @@ interface ComponentsMap {
   ],
   [BotChatInputCommandName.CREATE_PACK]: [
     'createPackModalTitle',
+    'nameLabel',
+    'nameDescription',
+    'publicChoiceLabel',
+    'publicChoiceDescription',
+    'publicTrueLabel',
+    'publicTrueDescription',
+    'publicFalseLabel',
+    'publicFalseDescription',
+    'nsfwChoiceLabel',
+    'nsfwChoiceDescription',
+    'nsfwTrueLabel',
+    'nsfwTrueDescription',
+    'nsfwFalseLabel',
+    'nsfwFalseDescription',
+  ],
+  [BotChatInputCommandName.EDIT_PACK]: [
+    'editPackModalTitle',
     'nameLabel',
     'nameDescription',
     'publicChoiceLabel',

--- a/src/utils/interactions.ts
+++ b/src/utils/interactions.ts
@@ -8,6 +8,7 @@ import { createPackCommand } from '../commands/create-pack.command.js';
 import { createStickerCommand } from '../commands/create-sticker.command.js';
 import { deletePackCommand } from '../commands/delete-pack.command.js';
 import { deleteStickerCommand } from '../commands/delete-sticker.command.js';
+import { editPackCommand } from '../commands/edit-pack.command.js';
 import { editStickerCommand } from '../commands/edit-sticker.command.js';
 import { importCommand } from '../commands/import.command.js';
 import { nsfwPackCommand } from '../commands/nsfw-pack.command.js';
@@ -30,6 +31,7 @@ export const chatInputCommandRegistry = createChatInputCommandRegistry([
   editStickerCommand,
   deleteStickerCommand,
   deletePackCommand,
+  editPackCommand,
 ]);
 
 export const contextMenuCommandRegistry = createContextMenuCommandRegistry([


### PR DESCRIPTION
## Summary
- Adds a new `/edit-pack` command allowing pack owners to update a sticker pack's name, public visibility, and NSFW status via a modal pre-filled with current values.
- Mirrors the existing `create-pack` (modal UI, name validation) and `delete-pack` (ownership-checked lookup) command patterns.
- Reuses the `'edit'` action already supported by `postPackToFeed` for before/after diff logging — no changes needed there.
- No DB migration needed; `name`, `public`, and `nsfw` columns already exist on `Pack`.

Closes #16

## Test plan
- [x] `npm run build` (tsc, including the compile-time translation-validator check)
- [x] `npm run lint`
- [x] `npx vitest run`
- [ ] Manual verification in a live Discord server (not possible in this environment — please verify the modal flow, pre-filled values, and feed webhook message before merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)