### PR TITLE
feat: add pagination to /pack and /nsfw-pack

### DIFF
--- a/src/commands/command-handlers/pack.command-handler.ts
+++ b/src/commands/command-handlers/pack.command-handler.ts
@@ -9,11 +9,12 @@ export const packCommandHandler = (nsfw: boolean): CommandHandler => async funct
   const packId = interaction.options.getString(PackCommandOptionName.NAME) ?? undefined;
   const pack = await db.pack.findFirst({
     where: {
-      OR: [
-        { id: packId },
-        { name: packId },
+      AND: [
+        { OR: [{ id: packId }, { name: packId }] },
+        { OR: [{ public: true }, { createdBy: BigInt(interaction.user.id) }] },
       ],
       nsfw: nsfw ? undefined : false,
+      deletedAt: null,
     },
   });
   if (!pack) {

--- a/src/commands/command-handlers/pack.command-handler.ts
+++ b/src/commands/command-handlers/pack.command-handler.ts
@@ -1,11 +1,8 @@
-import { ComponentType, MessageFlags } from 'discord-api-types/v10';
+import { MessageFlags } from 'discord-api-types/v10';
 import { CommandHandler } from '../../types/bot-interaction.js';
 import { PackCommandOptionName } from '../../types/localization.js';
-import { getFormattedPackName } from '../../utils/get-formatted-pack-name.js';
+import { getPackPreviewContent, packItemsPerPage } from '../../utils/get-pack-preview-content.js';
 import { interactionReply } from '../../utils/interaction-reply.js';
-import { mapStickersToGalleryItems } from '../../utils/map-stickers-to-gallery-items.js';
-
-const itemsPerPage = 9;
 
 export const packCommandHandler = (nsfw: boolean): CommandHandler => async function handle(interaction, context) {
   const { t, db } = context;
@@ -26,35 +23,21 @@ export const packCommandHandler = (nsfw: boolean): CommandHandler => async funct
     });
     return;
   }
+
+  const stickerCount = await db.sticker.count({
+    where: { deletedAt: null, packId: pack.id },
+  });
+  const totalPages = Math.max(1, Math.ceil(stickerCount / packItemsPerPage));
   const stickers = await db.sticker.findMany({
     where: {
       deletedAt: null,
       packId: pack.id,
     },
-    take: itemsPerPage,
+    take: packItemsPerPage,
     orderBy: { order: 'asc' },
   });
 
-  const { files, items } = mapStickersToGalleryItems(stickers, pack.nsfw);
+  const { flags, components, files } = getPackPreviewContent({ t, pack, stickers, page: 0, totalPages });
 
-  await interactionReply(context, interaction, {
-    flags: [MessageFlags.IsComponentsV2, MessageFlags.Ephemeral],
-    components: [
-      {
-        type: ComponentType.TextDisplay,
-        content: [
-          `# ${getFormattedPackName(pack)}`,
-          items.length === 0
-            ? t('commands.pack.responses.emptyPack')
-            : t('commands.pack.components.packPreview'),
-        ].join('\n'),
-      },
-      {
-        type: ComponentType.MediaGallery,
-        items,
-      },
-      // TODO Paging buttons
-    ],
-    files,
-  });
+  await interactionReply(context, interaction, { flags, components, files });
 };

--- a/src/commands/delete-pack.command.ts
+++ b/src/commands/delete-pack.command.ts
@@ -20,7 +20,7 @@ export const deletePackCommand: BotChatInputCommand = {
     };
   },
   autocomplete: {
-    [DeletePackCommandOptionName.NAME]: getPackNameAutocompleteHandler({ ownedOnly: true }),
+    [DeletePackCommandOptionName.NAME]: getPackNameAutocompleteHandler({ nsfw: true, ownedOnly: true }),
   },
   async handle(interaction, context) {
     const { t, db } = context;

--- a/src/commands/edit-pack.command.ts
+++ b/src/commands/edit-pack.command.ts
@@ -27,7 +27,7 @@ export const editPackCommand: BotChatInputCommand = {
     };
   },
   autocomplete: {
-    [EditPackCommandOptionName.NAME]: getPackNameAutocompleteHandler({ ownedOnly: true }),
+    [EditPackCommandOptionName.NAME]: getPackNameAutocompleteHandler({ nsfw: true, ownedOnly: true }),
   },
   async handle(interaction, context) {
     const { t, db } = context;

--- a/src/components/component-definitions/pack-page.component-definition.ts
+++ b/src/components/component-definitions/pack-page.component-definition.ts
@@ -1,0 +1,39 @@
+import { ButtonStyle } from 'discord-api-types/v10';
+import { ComponentType } from 'discord.js';
+import { EmojiCharacters } from '../../constants/emoji-characters.js';
+import {
+  BotMessageComponentCustomId,
+  BotMessageComponentDefinitionGetter,
+} from '../../types/bot-interaction.js';
+
+export const packPageFirstComponentDefinition: BotMessageComponentDefinitionGetter = (t) => ({
+  type: ComponentType.Button,
+  custom_id: BotMessageComponentCustomId.PACK_PAGE_FIRST,
+  label: t('commands.pack.components.firstPageButton'),
+  style: ButtonStyle.Secondary,
+  emoji: { name: EmojiCharacters.SKIP_BACK },
+});
+
+export const packPagePrevComponentDefinition: BotMessageComponentDefinitionGetter = (t) => ({
+  type: ComponentType.Button,
+  custom_id: BotMessageComponentCustomId.PACK_PAGE_PREV,
+  label: t('commands.pack.components.previousPageButton'),
+  style: ButtonStyle.Secondary,
+  emoji: { name: EmojiCharacters.ARROW_LEFT },
+});
+
+export const packPageNextComponentDefinition: BotMessageComponentDefinitionGetter = (t) => ({
+  type: ComponentType.Button,
+  custom_id: BotMessageComponentCustomId.PACK_PAGE_NEXT,
+  label: t('commands.pack.components.nextPageButton'),
+  style: ButtonStyle.Secondary,
+  emoji: { name: EmojiCharacters.ARROW_RIGHT },
+});
+
+export const packPageLastComponentDefinition: BotMessageComponentDefinitionGetter = (t) => ({
+  type: ComponentType.Button,
+  custom_id: BotMessageComponentCustomId.PACK_PAGE_LAST,
+  label: t('commands.pack.components.lastPageButton'),
+  style: ButtonStyle.Secondary,
+  emoji: { name: EmojiCharacters.SKIP_FORWARD },
+});

--- a/src/components/component-handlers/pack-page.component-handler.ts
+++ b/src/components/component-handlers/pack-page.component-handler.ts
@@ -14,7 +14,13 @@ export const packPageComponentHandler = (direction: 'first' | 'prev' | 'next' | 
   const currentPage = separatorIndex === -1 ? NaN : Number(resourceId?.substring(separatorIndex + 1));
 
   const pack = typeof packId === 'string' && !Number.isNaN(currentPage)
-    ? await db.pack.findUnique({ where: { id: packId, deletedAt: null } })
+    ? await db.pack.findFirst({
+      where: {
+        id: packId,
+        deletedAt: null,
+        OR: [{ public: true }, { createdBy: BigInt(interaction.user.id) }],
+      },
+    })
     : null;
 
   if (!pack) {

--- a/src/components/component-handlers/pack-page.component-handler.ts
+++ b/src/components/component-handlers/pack-page.component-handler.ts
@@ -1,0 +1,50 @@
+import { MessageFlags } from 'discord-api-types/v10';
+import { BotMessageComponentHandler } from '../../types/bot-interaction.js';
+import { getPackPreviewContent, packItemsPerPage } from '../../utils/get-pack-preview-content.js';
+import { interactionReply } from '../../utils/interaction-reply.js';
+
+export const packPageComponentHandler = (direction: 'first' | 'prev' | 'next' | 'last'): BotMessageComponentHandler => async (interaction, context, resourceId) => {
+  if (!interaction.isButton()) {
+    throw new Error('Button interaction expected');
+  }
+
+  const { t, db } = context;
+  const separatorIndex = resourceId?.lastIndexOf(':') ?? -1;
+  const packId = separatorIndex === -1 ? undefined : resourceId?.substring(0, separatorIndex);
+  const currentPage = separatorIndex === -1 ? NaN : Number(resourceId?.substring(separatorIndex + 1));
+
+  const pack = typeof packId === 'string' && !Number.isNaN(currentPage)
+    ? await db.pack.findUnique({ where: { id: packId, deletedAt: null } })
+    : null;
+
+  if (!pack) {
+    await interactionReply(context, interaction, {
+      content: t('commands.pack.responses.invalidPack'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const stickerCount = await db.sticker.count({
+    where: { deletedAt: null, packId: pack.id },
+  });
+  const totalPages = Math.max(1, Math.ceil(stickerCount / packItemsPerPage));
+  const requestedPage = {
+    first: 0,
+    prev: currentPage - 1,
+    next: currentPage + 1,
+    last: totalPages - 1,
+  }[direction];
+  const page = Math.min(Math.max(requestedPage, 0), totalPages - 1);
+
+  const stickers = await db.sticker.findMany({
+    where: { deletedAt: null, packId: pack.id },
+    take: packItemsPerPage,
+    skip: page * packItemsPerPage,
+    orderBy: { order: 'asc' },
+  });
+
+  const { components, files } = getPackPreviewContent({ t, pack, stickers, page, totalPages });
+
+  await interaction.update({ flags: MessageFlags.IsComponentsV2, components, files });
+};

--- a/src/components/pack-page-first.component.ts
+++ b/src/components/pack-page-first.component.ts
@@ -1,0 +1,13 @@
+import { BotMessageComponent, BotMessageComponentCustomId } from '../types/bot-interaction.js';
+import {
+  packPageFirstComponentDefinition,
+} from './component-definitions/pack-page.component-definition.js';
+import {
+  packPageComponentHandler,
+} from './component-handlers/pack-page.component-handler.js';
+
+export const packPageFirstComponent: BotMessageComponent = {
+  id: BotMessageComponentCustomId.PACK_PAGE_FIRST,
+  getDefinition: packPageFirstComponentDefinition,
+  handle: packPageComponentHandler('first'),
+};

--- a/src/components/pack-page-last.component.ts
+++ b/src/components/pack-page-last.component.ts
@@ -1,0 +1,13 @@
+import { BotMessageComponent, BotMessageComponentCustomId } from '../types/bot-interaction.js';
+import {
+  packPageLastComponentDefinition,
+} from './component-definitions/pack-page.component-definition.js';
+import {
+  packPageComponentHandler,
+} from './component-handlers/pack-page.component-handler.js';
+
+export const packPageLastComponent: BotMessageComponent = {
+  id: BotMessageComponentCustomId.PACK_PAGE_LAST,
+  getDefinition: packPageLastComponentDefinition,
+  handle: packPageComponentHandler('last'),
+};

--- a/src/components/pack-page-next.component.ts
+++ b/src/components/pack-page-next.component.ts
@@ -1,0 +1,13 @@
+import { BotMessageComponent, BotMessageComponentCustomId } from '../types/bot-interaction.js';
+import {
+  packPageNextComponentDefinition,
+} from './component-definitions/pack-page.component-definition.js';
+import {
+  packPageComponentHandler,
+} from './component-handlers/pack-page.component-handler.js';
+
+export const packPageNextComponent: BotMessageComponent = {
+  id: BotMessageComponentCustomId.PACK_PAGE_NEXT,
+  getDefinition: packPageNextComponentDefinition,
+  handle: packPageComponentHandler('next'),
+};

--- a/src/components/pack-page-prev.component.ts
+++ b/src/components/pack-page-prev.component.ts
@@ -1,0 +1,13 @@
+import { BotMessageComponent, BotMessageComponentCustomId } from '../types/bot-interaction.js';
+import {
+  packPagePrevComponentDefinition,
+} from './component-definitions/pack-page.component-definition.js';
+import {
+  packPageComponentHandler,
+} from './component-handlers/pack-page.component-handler.js';
+
+export const packPagePrevComponent: BotMessageComponent = {
+  id: BotMessageComponentCustomId.PACK_PAGE_PREV,
+  getDefinition: packPagePrevComponentDefinition,
+  handle: packPageComponentHandler('prev'),
+};

--- a/src/constants/emoji-characters.ts
+++ b/src/constants/emoji-characters.ts
@@ -11,4 +11,8 @@ export enum EmojiCharacters {
   LOCKED = '🔒',
   TRASH_CAN = '🗑️',
   RELOAD = '🔄',
+  ARROW_LEFT = '⬅️',
+  ARROW_RIGHT = '➡️',
+  SKIP_BACK = '⏮️',
+  SKIP_FORWARD = '⏭️',
 }

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -144,7 +144,12 @@
       },
       "components": {
         "emptyPack": "There are no stickers in this pack yet",
-        "packPreview": "Below is a preview of the stickers in this pack"
+        "packPreview": "Below is a preview of the stickers in this pack",
+        "firstPageButton": "First",
+        "previousPageButton": "Previous",
+        "nextPageButton": "Next",
+        "lastPageButton": "Last",
+        "pageIndicator": "Page {{page}} of {{totalPages}}"
       },
       "options": {
         "name": {

--- a/src/types/bot-interaction.ts
+++ b/src/types/bot-interaction.ts
@@ -44,6 +44,10 @@ export const enum BotModalId {
 export const enum BotMessageComponentCustomId {
   UPDATE_MESSAGE = 'update-message',
   DELETE_MESSAGE = 'delete-message',
+  PACK_PAGE_FIRST = 'pack-page-first',
+  PACK_PAGE_PREV = 'pack-page-prev',
+  PACK_PAGE_NEXT = 'pack-page-next',
+  PACK_PAGE_LAST = 'pack-page-last',
 }
 
 export type CommandHandler = FrameworkCommandHandler<UserInteractionContext>;

--- a/src/types/localization.ts
+++ b/src/types/localization.ts
@@ -165,7 +165,12 @@ interface ComponentsMap {
   ],
   [BotChatInputCommandName.PACK]: [
     'emptyPack',
-    'packPreview'
+    'packPreview',
+    'firstPageButton',
+    'previousPageButton',
+    'nextPageButton',
+    'lastPageButton',
+    'pageIndicator',
   ],
   [BotChatInputCommandName.EDIT_STICKER]: [
     'editStickerModalTitle',

--- a/src/utils/get-pack-preview-content.ts
+++ b/src/utils/get-pack-preview-content.ts
@@ -1,0 +1,94 @@
+import { ButtonStyle, ComponentType, MessageFlags } from 'discord-api-types/v10';
+import { APIMessageTopLevelComponent } from 'discord.js';
+import { TFunction } from 'i18next';
+import { EmojiCharacters } from '../constants/emoji-characters.js';
+import { Pack, Sticker } from '../generated/prisma/client.js';
+import { BotMessageComponentCustomId } from '../types/bot-interaction.js';
+import { getFormattedPackName } from './get-formatted-pack-name.js';
+import { mapStickersToGalleryItems } from './map-stickers-to-gallery-items.js';
+
+export const packItemsPerPage = 9;
+
+interface GetPackPreviewContentOptions {
+  t: TFunction;
+  pack: Pick<Pack, 'id' | 'name' | 'public' | 'nsfw'>;
+  stickers: Pick<Sticker, 'url' | 'description'>[];
+  page: number;
+  totalPages: number;
+}
+
+export const getPackPreviewContent = ({ t, pack, stickers, page, totalPages }: GetPackPreviewContentOptions) => {
+  const { files, items } = mapStickersToGalleryItems(stickers);
+
+  const components: APIMessageTopLevelComponent[] = [
+    {
+      type: ComponentType.TextDisplay,
+      content: [
+        `# ${getFormattedPackName(pack)}`,
+        items.length === 0
+          ? t('commands.pack.components.emptyPack')
+          : t('commands.pack.components.packPreview'),
+      ].join('\n'),
+    },
+  ];
+
+  if (items.length > 0) {
+    components.push({
+      type: ComponentType.MediaGallery,
+      items,
+    });
+  }
+
+  if (totalPages > 1) {
+    components.push({
+      type: ComponentType.ActionRow,
+      components: [
+        {
+          type: ComponentType.Button,
+          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_FIRST}:${pack.id}:${page}`,
+          label: t('commands.pack.components.firstPageButton'),
+          style: ButtonStyle.Secondary,
+          emoji: { name: EmojiCharacters.SKIP_BACK },
+          disabled: page <= 0,
+        },
+        {
+          type: ComponentType.Button,
+          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_PREV}:${pack.id}:${page}`,
+          label: t('commands.pack.components.previousPageButton'),
+          style: ButtonStyle.Secondary,
+          emoji: { name: EmojiCharacters.ARROW_LEFT },
+          disabled: page <= 0,
+        },
+        {
+          type: ComponentType.Button,
+          custom_id: 'pack-page-indicator',
+          label: t('commands.pack.components.pageIndicator', { page: page + 1, totalPages }),
+          style: ButtonStyle.Secondary,
+          disabled: true,
+        },
+        {
+          type: ComponentType.Button,
+          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_NEXT}:${pack.id}:${page}`,
+          label: t('commands.pack.components.nextPageButton'),
+          style: ButtonStyle.Secondary,
+          emoji: { name: EmojiCharacters.ARROW_RIGHT },
+          disabled: page >= totalPages - 1,
+        },
+        {
+          type: ComponentType.Button,
+          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_LAST}:${pack.id}:${page}`,
+          label: t('commands.pack.components.lastPageButton'),
+          style: ButtonStyle.Secondary,
+          emoji: { name: EmojiCharacters.SKIP_FORWARD },
+          disabled: page >= totalPages - 1,
+        },
+      ],
+    });
+  }
+
+  return {
+    flags: [MessageFlags.IsComponentsV2, MessageFlags.Ephemeral] as const,
+    components,
+    files,
+  };
+};

--- a/src/utils/handle-interaction.ts
+++ b/src/utils/handle-interaction.ts
@@ -75,7 +75,8 @@ export const handleInteraction = async (interaction: Interaction, baseContext: I
 
   if (interaction.isMessageComponent()) {
     const context = buildUserInteractionContext(baseContext, interaction, true);
-    if (!componentRegistry.isKnown(interaction.customId)) {
+    const { id: componentId } = parseCustomIdSegments(interaction.customId);
+    if (!componentRegistry.isKnown(componentId)) {
       await interactionReply(context, interaction, {
         content: `Unsupported component interaction with customId ${interaction.customId}`,
         flags: MessageFlags.Ephemeral,

--- a/src/utils/interactions.ts
+++ b/src/utils/interactions.ts
@@ -18,6 +18,10 @@ import { stickerCommand } from '../commands/sticker.command.js';
 import { stickerDetailsCommand } from '../commands/sticker-details.command.js';
 import { updateMessageCommand } from '../commands/update-message.command.js';
 import { deleteMessageComponent } from '../components/delete-message.component.js';
+import { packPageFirstComponent } from '../components/pack-page-first.component.js';
+import { packPageLastComponent } from '../components/pack-page-last.component.js';
+import { packPageNextComponent } from '../components/pack-page-next.component.js';
+import { packPagePrevComponent } from '../components/pack-page-prev.component.js';
 import { updateMessageComponent } from '../components/update-message.component.js';
 
 export const chatInputCommandRegistry = createChatInputCommandRegistry([
@@ -42,6 +46,10 @@ export const contextMenuCommandRegistry = createContextMenuCommandRegistry([
 export const componentRegistry = createComponentRegistry([
   updateMessageComponent,
   deleteMessageComponent,
+  packPageFirstComponent,
+  packPagePrevComponent,
+  packPageNextComponent,
+  packPageLastComponent,
 ]);
 
 export const modalRegistry = flattenCommandModals(chatInputCommandRegistry);

--- a/src/utils/map-stickers-to-gallery-items.ts
+++ b/src/utils/map-stickers-to-gallery-items.ts
@@ -18,10 +18,10 @@ export const mapStickersToGalleryItems = (stickers: Pick<Sticker, 'url' | 'descr
       };
     }
 
-    const attachmentUrl = `attachment://${paths.stickerFileName}`;
     const newFile = new AttachmentBuilder(paths.filePath, {
       name: paths.stickerFileName,
     }).setSpoiler(spoiler);
+    const attachmentUrl = `attachment://${newFile.name}`;
     return {
       galleryStickers: [...acc.galleryStickers, { ...sticker, url: attachmentUrl }],
       files: [


### PR DESCRIPTION
## Summary
- Adds First/Previous/Next/Last buttons and a "Page X of Y" indicator to the `/pack` and `/nsfw-pack` preview, so packs with more than 9 stickers can be paged through (finishes #13's remaining checkbox).
- Fixes a dispatch bug where `handle-interaction.ts` checked the component registry against the raw, unparsed `customId` instead of the parsed component id — this would have rejected any component using the `id:resourceId` convention that pagination relies on.
- Fixes NSFW pack previews sending spoilered attachments whose filename no longer matched the `attachment://` reference (caused a `DiscordAPIError[50035]` when viewing NSFW packs); NSFW pack previews are no longer spoilered.
- Fixes the empty-pack message resolving the wrong translation key (`responses.emptyPack` instead of `components.emptyPack`), which showed up as untranslated text.
- Fixes `/pack` and `/nsfw-pack` only filtering by `nsfw`, meaning anyone who knew or guessed a private pack's name/UUID could view its stickers via the free-text name option, bypassing the autocomplete list that only ever suggested public or owned packs. Now requires the pack to be public or owned by the invoking user (and not soft-deleted). The pagination button handler enforces the same rule.
- Fixes `/edit-pack` and `/delete-pack` autocomplete never suggesting NSFW packs, even though neither command displays sticker images and both already permit editing/deleting NSFW packs once an ID is supplied — brings them in line with `/import`, which already opts into `nsfw: true`.

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run lint`
- [x] `pnpm exec vitest run`
- [ ] Manually verify in a test guild: `/pack` and `/nsfw-pack` on a pack with >9 stickers, paging via First/Previous/Next/Last, disabled-state correctness at the first/last page, an empty pack showing the correctly translated message, `/pack` rejecting a private pack owned by another user, and `/edit-pack`/`/delete-pack` autocomplete listing NSFW packs

🤖 Generated with [Claude Code](https://claude.com/claude-code)