### PR TITLE
fix: include NSFW packs in edit-pack/delete-pack autocomplete

### DIFF
--- a/src/commands/delete-pack.command.ts
+++ b/src/commands/delete-pack.command.ts
@@ -20,7 +20,7 @@ export const deletePackCommand: BotChatInputCommand = {
     };
   },
   autocomplete: {
-    [DeletePackCommandOptionName.NAME]: getPackNameAutocompleteHandler({ ownedOnly: true }),
+    [DeletePackCommandOptionName.NAME]: getPackNameAutocompleteHandler({ nsfw: true, ownedOnly: true }),
   },
   async handle(interaction, context) {
     const { t, db } = context;

--- a/src/commands/edit-pack.command.ts
+++ b/src/commands/edit-pack.command.ts
@@ -27,7 +27,7 @@ export const editPackCommand: BotChatInputCommand = {
     };
   },
   autocomplete: {
-    [EditPackCommandOptionName.NAME]: getPackNameAutocompleteHandler({ ownedOnly: true }),
+    [EditPackCommandOptionName.NAME]: getPackNameAutocompleteHandler({ nsfw: true, ownedOnly: true }),
   },
   async handle(interaction, context) {
     const { t, db } = context;


### PR DESCRIPTION
## Summary
- `getPackNameAutocompleteHandler` defaults `nsfw` to `false`. `/edit-pack` and `/delete-pack` both called it with only `ownedOnly: true`, so NSFW packs never showed up as autocomplete suggestions even though neither command displays sticker images and both already permit editing/deleting NSFW packs once an ID is supplied.
- `/import` already passes `nsfw: true` alongside `ownedOnly: true` for the same reason — this brings `/edit-pack` and `/delete-pack` in line with that existing pattern.

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run lint`
- [x] `pnpm exec vitest run`
- [ ] Manually verify `/edit-pack` and `/delete-pack` autocomplete now list NSFW packs the user owns

🤖 Generated with [Claude Code](https://claude.com/claude-code)