### PR TITLE
ci: cache the Postgres image for docker-build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,28 @@ jobs:
       - name: Build images
         run: docker compose build
 
+      - name: Determine Postgres image cache key
+        id: postgres-cache-key
+        run: echo "week=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Postgres image
+        id: cache-postgres-image
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: /tmp/docker-image-cache/postgres.tar
+          key: postgres-image-${{ steps.postgres-cache-key.outputs.week }}
+
+      - name: Load cached Postgres image
+        if: steps.cache-postgres-image.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/docker-image-cache/postgres.tar
+
+      - name: Pull and cache Postgres image
+        if: steps.cache-postgres-image.outputs.cache-hit != 'true'
+        run: |
+          docker compose pull postgres
+          mkdir -p /tmp/docker-image-cache
+          docker save postgres:latest -o /tmp/docker-image-cache/postgres.tar
+
       - name: Start Postgres and wait for healthy
         run: docker compose up -d --wait --wait-timeout 60 postgres
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Cache Postgres image
         id: cache-postgres-image
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/docker-image-cache/postgres.tar
           key: postgres-image-${{ steps.postgres-cache-key.outputs.week }}


### PR DESCRIPTION
## Summary
- The `Docker Compose build & migration check` job runs on a fresh GitHub-hosted runner every time, so `postgres:latest` gets pulled from Docker Hub on every single run.
- Adds an `actions/cache` step that saves a `docker save` tarball of the image and restores it on later runs, keyed by ISO week (`YYYY-Www`) so it refreshes periodically rather than pinning a stale image indefinitely (the compose file intentionally tracks `postgres:latest`, not a fixed version).
- On a cache hit, `docker load` restores the image instantly instead of pulling; on a miss, it pulls once and saves it for next time.

## Test plan
- [ ] Confirm the `docker-build` job passes and the first run populates the cache (cache miss, pull + save)
- [ ] Confirm a subsequent run within the same ISO week hits the cache and skips the pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)