### PR TITLE
feat: add /publish-imported-pack command and per-sticker NSFW ratings

### DIFF
--- a/prisma/migrations/20260723212445_add_sticker_nsfw_override/migration.sql
+++ b/prisma/migrations/20260723212445_add_sticker_nsfw_override/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "Sticker" ADD COLUMN     "nsfwOverride" BOOLEAN;
+
+-- Enforce at most one published (public) copy per Telegram pack
+CREATE UNIQUE INDEX "Pack_telegramPackId_public_unique"
+  ON "Pack" ("telegramPackId")
+  WHERE "public" = true AND "deletedAt" IS NULL AND "telegramPackId" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,6 +95,8 @@ model Sticker {
   order             Int              @default(0)
   telegramSticker   TelegramSticker? @relation(fields: [telegramStickerId], references: [id])
   telegramStickerId String?          @db.Uuid
+  // Tri-state rating override: null = inherit Pack.nsfw, false = force SFW, true = force NSFW
+  nsfwOverride      Boolean?
   stickerMessages   StickerMessage[] @ignore
 
   @@index([deletedAt])

--- a/src/classes/queue-handlers/telegram-import.queue-handler.ts
+++ b/src/classes/queue-handlers/telegram-import.queue-handler.ts
@@ -25,6 +25,7 @@ import { getPackNsfwEmoji } from '../../utils/get-pack-nsfw-emoji.js';
 import { getPackVisibilityEmoji } from '../../utils/get-pack-visibility-emoji.js';
 import { mapStickersToGalleryItems } from '../../utils/map-stickers-to-gallery-items.js';
 import { emoji } from '../../utils/messaging.js';
+import { resolveStickerNsfw } from '../../utils/resolve-sticker-nsfw.js';
 import { rest } from '../../utils/rest.js';
 import {
   createTelegramApiClient,
@@ -329,6 +330,20 @@ export const telegramImportQueueHandler = (logger: NestableLogger): QueueHandler
       const liveTelegramStickerIds = new Set(liveTelegramStickers.map(ts => ts.id));
       const staleTelegramStickerIds = staleTelegramStickers.map(s => s.id);
 
+      // If this Telegram pack already has a published (public) copy, seed brand-new
+      // sticker rows for every other subscriber from its names/ratings instead of
+      // leaving them blank; existing rows are never touched, so nobody's own edits
+      // are overwritten
+      const publishedPack = await tx.pack.findFirst({
+        where: { telegramPackId: telegramPack.id, public: true, deletedAt: null },
+      });
+      const publishedStickers = publishedPack
+        ? await tx.sticker.findMany({
+          where: { packId: publishedPack.id, telegramStickerId: { not: null }, deletedAt: null },
+        })
+        : [];
+      const publishedByTelegramStickerId = new Map(publishedStickers.map(s => [s.telegramStickerId as string, s]));
+
       // Every user's view of this Telegram pack mirrors the shared rows
       const subscriberPacks = await tx.pack.findMany({
         where: { telegramPackId: telegramPack.id, deletedAt: null },
@@ -343,13 +358,15 @@ export const telegramImportQueueHandler = (logger: NestableLogger): QueueHandler
         for (const telegramStickerId of liveTelegramStickerIds) {
           const row = rowsByTelegramStickerId.get(telegramStickerId);
           if (!row) {
+            const publishedSticker = publishedByTelegramStickerId.get(telegramStickerId);
             const created = await tx.sticker.create({
               data: {
-                name: '',
+                name: publishedSticker?.name ?? '',
                 description: null,
                 packId: subscriberPack.id,
                 createdBy: subscriberPack.createdBy,
                 telegramStickerId,
+                nsfwOverride: publishedSticker?.nsfwOverride ?? null,
               },
             });
             if (subscriberPack.id === packId) {
@@ -449,7 +466,8 @@ const postImportedStickersToFeed = async ({ db, stickers, pack, telegramPack, im
 
   for (const sticker of stickers) {
     try {
-      const { items, files } = mapStickersToGalleryItems([sticker], pack.nsfw);
+      const spoiler = resolveStickerNsfw(sticker, pack);
+      const { items, files } = mapStickersToGalleryItems([sticker], spoiler);
       const replyMessage = await webhookClient.send({
         flags: MessageFlags.SuppressNotifications,
         content: [
@@ -458,7 +476,7 @@ const postImportedStickersToFeed = async ({ db, stickers, pack, telegramPack, im
           '**Description:** _(empty)_',
           `**Pack:** \`${wrapUrlsInAngleBrackets(telegramPack.title)}\` (\`${pack.id}\`) ${getPackVisibilityEmoji(pack)}${getPackNsfwEmoji(pack)}`,
           `**Imported by:** ${userMention(importedBy)} (\`${importedBy}\`)`,
-          `**Image:** ${items.filter(item => !item.media.url.startsWith('attachment://')).map(item => pack.nsfw ? `||${item.media.url}||` : item.media.url).join(' ')}`,
+          `**Image:** ${items.filter(item => !item.media.url.startsWith('attachment://')).map(item => spoiler ? `||${item.media.url}||` : item.media.url).join(' ')}`,
         ].join('\n'),
         files,
       });

--- a/src/classes/queue-handlers/update-message.queue-handler.ts
+++ b/src/classes/queue-handlers/update-message.queue-handler.ts
@@ -10,6 +10,7 @@ import { NestableLogger } from '@wentthefox-org/discord-bot-framework/logger';
 import { QueueHandler, QueueType } from '../../types/queue.js';
 import { createDb } from '../../utils/create-db.js';
 import { mapStickersToGalleryItems } from '../../utils/map-stickers-to-gallery-items.js';
+import { resolveStickerNsfw } from '../../utils/resolve-sticker-nsfw.js';
 import { rest } from '../../utils/rest.js';
 import { runAttempts } from '@wentthefox-org/discord-bot-framework/utils';
 
@@ -75,10 +76,16 @@ export const updateMessageQueueHandler = (logger: NestableLogger): QueueHandler<
     case 'update': {
       if (!newUrl) break;
 
+      const db = createDb();
+      const sticker = await db.sticker.findUnique({
+        where: { id: stickerId },
+        include: { pack: true },
+      });
+      const spoiler = sticker ? resolveStickerNsfw(sticker, sticker.pack) : false;
       const { files, items } = mapStickersToGalleryItems([{
         url: newUrl,
         description: description ?? null,
-      }]);
+      }], spoiler);
       const patchRequest: RequestData = {
         body: {
           flags: MessageFlags.IsComponentsV2,

--- a/src/commands/command-handlers/pack.command-handler.ts
+++ b/src/commands/command-handlers/pack.command-handler.ts
@@ -29,22 +29,24 @@ export const packCommandHandler = (nsfw: boolean): CommandHandler => async funct
     return;
   }
 
-  const stickerCount = await db.sticker.count({
-    where: { deletedAt: null, packId: pack.id },
-  });
+  // Stickers explicitly overridden to NSFW never appear in the non-NSFW commands,
+  // even inside an otherwise safe-for-all-audiences pack
+  const stickerWhere = {
+    deletedAt: null,
+    packId: pack.id,
+    ...(nsfw ? {} : { NOT: { nsfwOverride: true } }),
+  };
+  const stickerCount = await db.sticker.count({ where: stickerWhere });
   const totalPages = Math.max(1, Math.ceil(stickerCount / packItemsPerPage));
   const stickers = await db.sticker.findMany({
-    where: {
-      deletedAt: null,
-      packId: pack.id,
-    },
+    where: stickerWhere,
     include: { telegramSticker: true },
     take: packItemsPerPage,
     // Imported sticker order lives on the shared TelegramSticker row
     orderBy: pack.telegramPackId !== null ? { telegramSticker: { order: 'asc' } } : { order: 'asc' },
   });
 
-  const { flags, components, files } = getPackPreviewContent({ t, pack, stickers, page: 0, totalPages });
+  const { flags, components, files } = getPackPreviewContent({ t, pack, stickers, page: 0, totalPages, nsfw });
 
   await interactionReply(context, interaction, { flags, components, files });
 };

--- a/src/commands/command-handlers/sticker.command-handler.ts
+++ b/src/commands/command-handlers/sticker.command-handler.ts
@@ -39,8 +39,11 @@ export const stickerCommandHandler = (nsfw: boolean): CommandHandler => async fu
       packId: {
         in: availablePacks.map(pack => pack.id),
       },
+      // Stickers explicitly overridden to NSFW never appear in the non-NSFW commands,
+      // even inside an otherwise safe-for-all-audiences pack
+      ...(nsfw ? {} : { NOT: { nsfwOverride: true } }),
     },
-    include: { telegramSticker: true },
+    include: { telegramSticker: true, pack: true },
     take: 1,
   });
   if (!stickers) {

--- a/src/commands/edit-pack.command.ts
+++ b/src/commands/edit-pack.command.ts
@@ -66,6 +66,13 @@ export const editPackCommand: BotChatInputCommand = {
             type: ComponentType.TextDisplay as const,
             content: `${EmojiCharacters.INFO} ${t('commands.edit-pack.components.importedNameNote')}`,
           } as const,
+          // Unpublished imported packs can only become public via /publish-imported-pack
+          ...(pack.public ? [] : [
+            {
+              type: ComponentType.TextDisplay as const,
+              content: `${EmojiCharacters.INFO} ${t('commands.edit-pack.components.importedUnpublishedNote')}`,
+            } as const,
+          ]),
         ] : [
           {
             type: ComponentType.Label as const,
@@ -82,8 +89,11 @@ export const editPackCommand: BotChatInputCommand = {
             } as TextInputComponentData,
           },
         ]),
-        // Imported packs always stay private, so no visibility choice is offered for them
-        ...(pack.telegramPackId !== null ? [] : [
+        // Imported packs can only ever go from public back to private here — becoming
+        // public in the first place requires /publish-imported-pack — so the choice is
+        // only offered once a pack is already published; unpublished imported packs
+        // get the informational note above instead
+        ...(pack.telegramPackId === null || pack.public ? [
           {
             type: ComponentType.Label as const,
             label: t('commands.edit-pack.components.publicChoiceLabel'),
@@ -101,13 +111,15 @@ export const editPackCommand: BotChatInputCommand = {
                 {
                   value: EditPackModalBooleanOption.FALSE,
                   label: `${getPackVisibilityEmoji({ public: false })} ${t('commands.edit-pack.components.publicFalseLabel')}`,
-                  description: t('commands.edit-pack.components.publicFalseDescription'),
+                  description: t(pack.telegramPackId !== null
+                    ? 'commands.edit-pack.components.publicFalseDescriptionImported'
+                    : 'commands.edit-pack.components.publicFalseDescription'),
                   default: !pack.public,
                 },
               ],
             } as unknown as ComponentInLabelData,
           },
-        ]),
+        ] : []),
         {
           type: ComponentType.Label,
           label: t('commands.edit-pack.components.nsfwChoiceLabel'),

--- a/src/commands/edit-sticker.command.ts
+++ b/src/commands/edit-sticker.command.ts
@@ -1,5 +1,5 @@
 import { ComponentType, MessageFlags, TextInputStyle } from 'discord-api-types/v10';
-import { TextInputComponentData } from 'discord.js';
+import { ComponentInLabelData, TextInputComponentData } from 'discord.js';
 import { EmojiCharacters } from '../constants/emoji-characters.js';
 import { getEditStickerOptions } from '../options/edit-sticker.options.js';
 import { stickerAltOptionMeta } from '../options/metadata/sticker-alt.option-meta.js';
@@ -17,6 +17,7 @@ import { interactionReply } from '../utils/interaction-reply.js';
 import { updateOrCreateUser } from '../utils/messaging.js';
 import {
   EditStickerModalCustomIds,
+  EditStickerRatingOption,
   editStickerModalHandler,
 } from './modal-handlers/edit-sticker.modal-handler.js';
 
@@ -120,6 +121,35 @@ export const editStickerCommand: BotChatInputCommand = {
             required: false,
             value: sticker.description ?? undefined,
           } as TextInputComponentData,
+        },
+        {
+          type: ComponentType.Label,
+          label: t('commands.edit-sticker.components.ratingChoiceLabel'),
+          description: t('commands.edit-sticker.components.ratingChoiceDescription'),
+          component: {
+            type: ComponentType.RadioGroup,
+            customId: EditStickerModalCustomIds.RATING_INPUT,
+            options: [
+              {
+                value: EditStickerRatingOption.DEFAULT,
+                label: t('commands.edit-sticker.components.ratingDefaultLabel'),
+                description: t('commands.edit-sticker.components.ratingDefaultDescription'),
+                default: sticker.nsfwOverride === null,
+              },
+              {
+                value: EditStickerRatingOption.SFW,
+                label: t('commands.edit-sticker.components.ratingSfwLabel'),
+                description: t('commands.edit-sticker.components.ratingSfwDescription'),
+                default: sticker.nsfwOverride === false,
+              },
+              {
+                value: EditStickerRatingOption.NSFW,
+                label: t('commands.edit-sticker.components.ratingNsfwLabel'),
+                description: t('commands.edit-sticker.components.ratingNsfwDescription'),
+                default: sticker.nsfwOverride === true,
+              },
+            ],
+          } as unknown as ComponentInLabelData,
         },
         ...(isImportedSticker ? [] : [
           {

--- a/src/commands/modal-handlers/delete-sticker.modal-handler.ts
+++ b/src/commands/modal-handlers/delete-sticker.modal-handler.ts
@@ -53,6 +53,7 @@ export const deleteStickerModalHandler: ModalHandler = async (interaction, conte
     name: sticker.name,
     description: sticker.description,
     url: sticker.url,
+    nsfwOverride: sticker.nsfwOverride,
   };
 
   const {

--- a/src/commands/modal-handlers/edit-pack.modal-handler.ts
+++ b/src/commands/modal-handlers/edit-pack.modal-handler.ts
@@ -112,8 +112,12 @@ export const editPackModalHandler: ModalHandler = async (interaction, context, r
     where: { id: pack.id },
     data: {
       ...(!isImportedPack && packName !== null ? { name: packName } : undefined),
-      // Imported packs always stay private
-      public: !isImportedPack && data[EditPackModalCustomIds.PUBLIC_INPUT] === EditPackModalBooleanOption.TRUE,
+      // Imported packs can only become public via /publish-imported-pack; the visibility
+      // radio is only shown here once a pack is already published, letting the owner
+      // unpublish it again (private → public is never accepted through this modal)
+      public: isImportedPack
+        ? (pack.public && data[EditPackModalCustomIds.PUBLIC_INPUT] === EditPackModalBooleanOption.TRUE)
+        : data[EditPackModalCustomIds.PUBLIC_INPUT] === EditPackModalBooleanOption.TRUE,
       nsfw: data[EditPackModalCustomIds.NSFW_INPUT] === EditPackModalBooleanOption.TRUE,
     },
     include: { telegramPack: true },

--- a/src/commands/modal-handlers/edit-sticker.modal-handler.ts
+++ b/src/commands/modal-handlers/edit-sticker.modal-handler.ts
@@ -21,7 +21,22 @@ export enum EditStickerModalCustomIds {
   NEW_ALT_INPUT = 'newAltInput',
   NEW_FILE_INPUT = 'newFileInput',
   NEW_URL_INPUT = 'newUrlInput',
+  RATING_INPUT = 'ratingInput',
 }
+
+export enum EditStickerRatingOption {
+  DEFAULT = 'default',
+  SFW = 'sfw',
+  NSFW = 'nsfw',
+}
+
+const parseRatingOption = (value: string | null): boolean | null => {
+  switch (value) {
+    case EditStickerRatingOption.SFW: return false;
+    case EditStickerRatingOption.NSFW: return true;
+    default: return null;
+  }
+};
 
 export const editStickerModalHandler: ModalHandler = async (interaction, context, resourceId) => {
   const { t, db } = context;
@@ -50,6 +65,7 @@ export const editStickerModalHandler: ModalHandler = async (interaction, context
     name: sticker.name,
     description: sticker.description,
     url: sticker.url,
+    nsfwOverride: sticker.nsfwOverride,
   };
 
   const {
@@ -166,12 +182,14 @@ export const editStickerModalHandler: ModalHandler = async (interaction, context
     }
   }
   const description = normalizeStickerDescriptionInput(data[EditStickerModalCustomIds.NEW_ALT_INPUT]);
+  const nsfwOverride = parseRatingOption(data[EditStickerModalCustomIds.RATING_INPUT]);
   sticker = await db.sticker.update({
     where: { id: sticker.id },
     data: {
       name: stickerName ?? sticker.name,
       description,
       url: stickerUrl,
+      nsfwOverride,
     },
     include: { pack: { include: { telegramPack: true } }, telegramSticker: true },
   });

--- a/src/commands/modal-handlers/mass-rename-sticker.modal-handler.ts
+++ b/src/commands/modal-handlers/mass-rename-sticker.modal-handler.ts
@@ -95,6 +95,7 @@ export const massRenameStickerModalHandler: ModalHandler = async (interaction, c
     name: sticker.name,
     description: sticker.description,
     url: sticker.url,
+    nsfwOverride: sticker.nsfwOverride,
   };
   if (nameChanged) {
     sticker = await db.sticker.update({

--- a/src/commands/modal-handlers/publish-edit-sticker.modal-handler.ts
+++ b/src/commands/modal-handlers/publish-edit-sticker.modal-handler.ts
@@ -1,0 +1,118 @@
+import { MessageFlags } from 'discord-api-types/v10';
+import {
+  stickerNameInvalidPattern,
+  stickerNameOptionMeta,
+} from '../../options/metadata/sticker-name.option-meta.js';
+import { ModalHandler } from '../../types/bot-interaction.js';
+import { getPublishStepContent } from '../../utils/get-publish-pack-content.js';
+import { interactionReply } from '../../utils/interaction-reply.js';
+import { collectModalSubmittedData, updateOrCreateUser } from '../../utils/messaging.js';
+import { postStickerToFeed, StickerSnapshot } from '../../utils/post-sticker-to-feed.js';
+
+export enum PublishEditStickerModalCustomIds {
+  NEW_NAME_INPUT = 'newNameInput',
+  RATING_INPUT = 'ratingInput',
+}
+
+export enum PublishRatingOption {
+  SFW = 'sfw',
+  NSFW = 'nsfw',
+}
+
+export const publishEditStickerModalHandler: ModalHandler = async (interaction, context, resourceId) => {
+  const { t, db } = context;
+  const user = await updateOrCreateUser(context, interaction);
+  if (user.readOnly) {
+    await interactionReply(context, interaction, {
+      content: t('commands.global.responses.noPermission'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  let sticker = resourceId ? await db.sticker.findUnique({
+    where: { id: resourceId, deletedAt: null, createdBy: user.id },
+    include: { pack: { include: { telegramPack: true } }, telegramSticker: true },
+  }) : null;
+
+  if (!sticker) {
+    await interactionReply(context, interaction, {
+      content: t('commands.publish-imported-pack.responses.stickerNotFound'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const { data } = collectModalSubmittedData(interaction, PublishEditStickerModalCustomIds);
+
+  const stickerName = data[PublishEditStickerModalCustomIds.NEW_NAME_INPUT];
+  if (stickerName === null || stickerName.length < stickerNameOptionMeta.min_length) {
+    await interactionReply(context, interaction, {
+      content: t('commands.create-sticker.responses.nameTooShot'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+  if (stickerName.length > stickerNameOptionMeta.max_length) {
+    await interactionReply(context, interaction, {
+      content: t('commands.create-sticker.responses.nameTooLong'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+  const invalidChars = new Set(stickerName.match(stickerNameInvalidPattern));
+  if (invalidChars.size > 0) {
+    await interactionReply(context, interaction, {
+      content: t('commands.create-sticker.responses.invalidName', {
+        chars: '```\n' + Array.from(invalidChars).join('') + '\n```',
+      }),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const nsfwOverride = data[PublishEditStickerModalCustomIds.RATING_INPUT] === PublishRatingOption.NSFW;
+
+  const nameChanged = stickerName !== sticker.name;
+  const ratingChanged = nsfwOverride !== sticker.nsfwOverride;
+  const stickerSnapshot: StickerSnapshot = {
+    name: sticker.name,
+    description: sticker.description,
+    url: sticker.url,
+    nsfwOverride: sticker.nsfwOverride,
+  };
+  if (nameChanged || ratingChanged) {
+    sticker = await db.sticker.update({
+      where: { id: sticker.id },
+      data: { name: stickerName, nsfwOverride },
+      include: { pack: { include: { telegramPack: true } }, telegramSticker: true },
+    });
+  }
+
+  const nextContent = await getPublishStepContent({
+    t,
+    db,
+    pack: sticker.pack,
+    currentStickerId: sticker.id,
+    direction: 'next',
+  });
+  if (interaction.isFromMessage()) {
+    await interaction.update({ flags: MessageFlags.IsComponentsV2, ...nextContent });
+  } else {
+    await interactionReply(context, interaction, {
+      flags: [MessageFlags.IsComponentsV2, MessageFlags.Ephemeral],
+      ...nextContent,
+    });
+  }
+
+  if (nameChanged || ratingChanged) {
+    await postStickerToFeed({
+      context,
+      interaction,
+      sticker,
+      userPack: sticker.pack,
+      action: 'edit',
+      snapshot: stickerSnapshot,
+    });
+  }
+};

--- a/src/commands/publish-imported-pack.command.ts
+++ b/src/commands/publish-imported-pack.command.ts
@@ -1,0 +1,110 @@
+import { MessageFlags } from 'discord-api-types/v10';
+import { userMention } from 'discord.js';
+import { getPublishImportedPackOptions } from '../options/publish-imported-pack.options.js';
+import { BotChatInputCommand, BotChatInputCommandName, BotModalId } from '../types/bot-interaction.js';
+import { PublishImportedPackCommandOptionName } from '../types/localization.js';
+import { getPackNameAutocompleteHandler } from '../utils/autocomplete/pack-name.autocomplete.js';
+import {
+  getPublishStickerContent,
+  isStickerPublishReady,
+} from '../utils/get-publish-pack-content.js';
+import { findOrderedPackStickers } from '../utils/get-mass-rename-content.js';
+import { getLocalizedObject } from '../utils/get-localized-object.js';
+import { interactionReply } from '../utils/interaction-reply.js';
+import { updateOrCreateUser } from '../utils/messaging.js';
+import {
+  publishEditStickerModalHandler,
+} from './modal-handlers/publish-edit-sticker.modal-handler.js';
+
+export const publishImportedPackCommand: BotChatInputCommand = {
+  name: BotChatInputCommandName.PUBLISH_IMPORTED_PACK,
+  getDefinition: (t) => {
+    if (!t) throw new Error('Missing translation function');
+    return {
+      ...getLocalizedObject('description', (lng) => t('commands.publish-imported-pack.description', { lng })),
+      ...getLocalizedObject('name', (lng) => t('commands.publish-imported-pack.name', { lng })),
+      options: getPublishImportedPackOptions(t),
+    };
+  },
+  autocomplete: {
+    [PublishImportedPackCommandOptionName.PACK]: getPackNameAutocompleteHandler({
+      nsfw: true,
+      ownedOnly: true,
+      importedOnly: true,
+    }),
+  },
+  async handle(interaction, context) {
+    const { t, db } = context;
+    const user = await updateOrCreateUser(context, interaction);
+    if (user.readOnly) {
+      await interactionReply(context, interaction, {
+        content: t('commands.global.responses.noPermission'),
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const packId = interaction.options.getString(PublishImportedPackCommandOptionName.PACK, true);
+    const pack = await db.pack.findFirst({
+      where: { id: packId, deletedAt: null, createdBy: user.id, telegramPackId: { not: null } },
+      include: { telegramPack: true },
+    });
+
+    if (!pack) {
+      await interactionReply(context, interaction, {
+        content: t('commands.publish-imported-pack.responses.packNotFound'),
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (pack.public) {
+      await interactionReply(context, interaction, {
+        content: t('commands.publish-imported-pack.responses.alreadyPublished'),
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const existingPublishedPack = await db.pack.findFirst({
+      where: { telegramPackId: pack.telegramPackId, public: true, deletedAt: null },
+      include: { creator: true },
+    });
+    if (existingPublishedPack) {
+      await interactionReply(context, interaction, {
+        content: t('commands.publish-imported-pack.responses.alreadyPublishedElsewhere', {
+          user: userMention(String(existingPublishedPack.createdBy)),
+        }),
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const stickers = await findOrderedPackStickers(db, pack);
+    if (stickers.length === 0) {
+      await interactionReply(context, interaction, {
+        content: t('commands.publish-imported-pack.responses.emptyPack'),
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const allReady = stickers.every(isStickerPublishReady);
+    const { components, files } = getPublishStickerContent({
+      t,
+      pack,
+      sticker: stickers[0],
+      index: 0,
+      total: stickers.length,
+      allReady,
+    });
+    await interactionReply(context, interaction, {
+      flags: [MessageFlags.IsComponentsV2, MessageFlags.Ephemeral],
+      components,
+      files,
+    });
+  },
+  modal: {
+    [BotModalId.PUBLISH_EDIT_STICKER]: publishEditStickerModalHandler,
+  },
+};

--- a/src/commands/sticker-details.command.ts
+++ b/src/commands/sticker-details.command.ts
@@ -6,6 +6,7 @@ import { getFormattedStickerName } from '../utils/get-formatted-sticker-name.js'
 import { getLocalizedObject } from '../utils/get-localized-object.js';
 import { interactionReply } from '../utils/interaction-reply.js';
 import { mapStickersToGalleryItems } from '../utils/map-stickers-to-gallery-items.js';
+import { resolveStickerNsfw } from '../utils/resolve-sticker-nsfw.js';
 
 export const stickerDetailsCommand: BotMessageContextMenuCommand = {
   name: BotMessageContextMenuCommandName.STICKER_DETAILS,
@@ -70,11 +71,12 @@ export const stickerDetailsCommand: BotMessageContextMenuCommand = {
 
       const outdatedLines: string[] = [];
       if (isOutdated) {
-        const { files, items } = mapStickersToGalleryItems([sticker], sticker.pack.nsfw);
+        const spoiler = resolveStickerNsfw(sticker, sticker.pack);
+        const { files, items } = mapStickersToGalleryItems([sticker], spoiler);
         allFiles.push(...files);
         const externalUrls = items
           .filter(item => !item.media.url.startsWith('attachment://'))
-          .map(item => sticker.pack.nsfw ? `||${item.media.url}||` : item.media.url);
+          .map(item => spoiler ? `||${item.media.url}||` : item.media.url);
         if (externalUrls.length > 0) {
           outdatedLines.push(`**${t('commands.Sticker Details.responses.latestImage')}:** ${externalUrls.join(' ')}`);
         }

--- a/src/commands/update-message.command.ts
+++ b/src/commands/update-message.command.ts
@@ -63,7 +63,7 @@ export const updateMessageCommand: BotMessageContextMenuCommand = {
         },
         deletedAt: null,
       },
-      include: { telegramSticker: true },
+      include: { telegramSticker: true, pack: true },
     });
 
     const stickerMessageByStickerId = new Map(stickerMessages.map(sm => [sm.stickerId, sm]));

--- a/src/components/component-definitions/publish.component-definition.ts
+++ b/src/components/component-definitions/publish.component-definition.ts
@@ -1,0 +1,46 @@
+import { ButtonStyle } from 'discord-api-types/v10';
+import { ComponentType } from 'discord.js';
+import { EmojiCharacters } from '../../constants/emoji-characters.js';
+import {
+  BotMessageComponentCustomId,
+  BotMessageComponentDefinitionGetter,
+} from '../../types/bot-interaction.js';
+
+export const publishOpenComponentDefinition: BotMessageComponentDefinitionGetter = (t) => ({
+  type: ComponentType.Button,
+  custom_id: BotMessageComponentCustomId.PUBLISH_OPEN,
+  label: t('commands.publish-imported-pack.components.editButton'),
+  style: ButtonStyle.Primary,
+  emoji: { name: EmojiCharacters.PENCIL },
+});
+
+export const publishPrevComponentDefinition: BotMessageComponentDefinitionGetter = (t) => ({
+  type: ComponentType.Button,
+  custom_id: BotMessageComponentCustomId.PUBLISH_PREV,
+  label: t('commands.publish-imported-pack.components.previousButton'),
+  style: ButtonStyle.Secondary,
+  emoji: { name: EmojiCharacters.ARROW_LEFT },
+});
+
+export const publishNextComponentDefinition: BotMessageComponentDefinitionGetter = (t) => ({
+  type: ComponentType.Button,
+  custom_id: BotMessageComponentCustomId.PUBLISH_NEXT,
+  label: t('commands.publish-imported-pack.components.nextButton'),
+  style: ButtonStyle.Secondary,
+  emoji: { name: EmojiCharacters.ARROW_RIGHT },
+});
+
+export const publishConfirmComponentDefinition: BotMessageComponentDefinitionGetter = (t) => ({
+  type: ComponentType.Button,
+  custom_id: BotMessageComponentCustomId.PUBLISH_CONFIRM,
+  label: t('commands.publish-imported-pack.components.publishButton'),
+  style: ButtonStyle.Success,
+  emoji: { name: EmojiCharacters.ROCKET },
+});
+
+export const publishJumpInvalidComponentDefinition: BotMessageComponentDefinitionGetter = (t) => ({
+  type: ComponentType.Button,
+  custom_id: BotMessageComponentCustomId.PUBLISH_JUMP_INVALID,
+  label: t('commands.publish-imported-pack.components.jumpToInvalidButton'),
+  style: ButtonStyle.Secondary,
+});

--- a/src/components/component-handlers/pack-page.component-handler.ts
+++ b/src/components/component-handlers/pack-page.component-handler.ts
@@ -9,11 +9,13 @@ export const packPageComponentHandler = (direction: 'first' | 'prev' | 'next' | 
   }
 
   const { t, db } = context;
-  const separatorIndex = resourceId?.lastIndexOf(':') ?? -1;
-  const packId = separatorIndex === -1 ? undefined : resourceId?.substring(0, separatorIndex);
-  const currentPage = separatorIndex === -1 ? NaN : Number(resourceId?.substring(separatorIndex + 1));
+  // Custom IDs are `<prefix>:<packId>:<page>:<nsfw>`; the pack ID is a UUID so it never
+  // contains a colon itself, making a plain split safe
+  const [packId, currentPageRaw, nsfwFlagRaw] = (resourceId ?? '').split(':');
+  const currentPage = currentPageRaw === undefined ? NaN : Number(currentPageRaw);
+  const nsfw = nsfwFlagRaw === '1';
 
-  const pack = typeof packId === 'string' && !Number.isNaN(currentPage)
+  const pack = typeof packId === 'string' && packId.length > 0 && !Number.isNaN(currentPage)
     ? await db.pack.findFirst({
       where: {
         id: packId,
@@ -32,9 +34,14 @@ export const packPageComponentHandler = (direction: 'first' | 'prev' | 'next' | 
     return;
   }
 
-  const stickerCount = await db.sticker.count({
-    where: { deletedAt: null, packId: pack.id },
-  });
+  // Stickers explicitly overridden to NSFW never appear in the non-NSFW commands,
+  // even inside an otherwise safe-for-all-audiences pack
+  const stickerWhere = {
+    deletedAt: null,
+    packId: pack.id,
+    ...(nsfw ? {} : { NOT: { nsfwOverride: true } }),
+  };
+  const stickerCount = await db.sticker.count({ where: stickerWhere });
   const totalPages = Math.max(1, Math.ceil(stickerCount / packItemsPerPage));
   const requestedPage = {
     first: 0,
@@ -45,7 +52,7 @@ export const packPageComponentHandler = (direction: 'first' | 'prev' | 'next' | 
   const page = Math.min(Math.max(requestedPage, 0), totalPages - 1);
 
   const stickers = await db.sticker.findMany({
-    where: { deletedAt: null, packId: pack.id },
+    where: stickerWhere,
     include: { telegramSticker: true },
     take: packItemsPerPage,
     skip: page * packItemsPerPage,
@@ -53,7 +60,7 @@ export const packPageComponentHandler = (direction: 'first' | 'prev' | 'next' | 
     orderBy: pack.telegramPackId !== null ? { telegramSticker: { order: 'asc' } } : { order: 'asc' },
   });
 
-  const { components, files } = getPackPreviewContent({ t, pack, stickers, page, totalPages });
+  const { components, files } = getPackPreviewContent({ t, pack, stickers, page, totalPages, nsfw });
 
   await interaction.update({ flags: MessageFlags.IsComponentsV2, components, files });
 };

--- a/src/components/component-handlers/publish.component-handler.ts
+++ b/src/components/component-handlers/publish.component-handler.ts
@@ -1,0 +1,271 @@
+import { ComponentType, MessageFlags, TextInputStyle } from 'discord-api-types/v10';
+import { ComponentInLabelData, TextInputComponentData, userMention } from 'discord.js';
+import {
+  PublishEditStickerModalCustomIds,
+  PublishRatingOption,
+} from '../../commands/modal-handlers/publish-edit-sticker.modal-handler.js';
+import { stickerNameOptionMeta } from '../../options/metadata/sticker-name.option-meta.js';
+import { BotMessageComponentHandler, BotModalId } from '../../types/bot-interaction.js';
+import { getFormattedPackName, getPackDisplayName } from '../../utils/get-formatted-pack-name.js';
+import { getFormattedStickerName } from '../../utils/get-formatted-sticker-name.js';
+import {
+  getPublishJumpToInvalidContent,
+  getPublishStepContent,
+  isStickerPublishReady,
+} from '../../utils/get-publish-pack-content.js';
+import { findOrderedPackStickers } from '../../utils/get-mass-rename-content.js';
+import { interactionReply } from '../../utils/interaction-reply.js';
+import { updateOrCreateUser } from '../../utils/messaging.js';
+import { PackSnapshot, postPackToFeed } from '../../utils/post-pack-to-feed.js';
+import { resolveStickerNsfw } from '../../utils/resolve-sticker-nsfw.js';
+
+export const publishOpenComponentHandler: BotMessageComponentHandler = async (interaction, context, resourceId) => {
+  if (!interaction.isButton()) {
+    throw new Error('Button interaction expected');
+  }
+
+  const { t, db } = context;
+  const user = await updateOrCreateUser(context, interaction);
+  if (user.readOnly) {
+    await interactionReply(context, interaction, {
+      content: t('commands.global.responses.noPermission'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const sticker = resourceId ? await db.sticker.findUnique({
+    where: { id: resourceId, deletedAt: null, createdBy: user.id },
+    include: { pack: { include: { telegramPack: true } }, telegramSticker: true },
+  }) : null;
+
+  if (!sticker) {
+    await interactionReply(context, interaction, {
+      content: t('commands.publish-imported-pack.responses.stickerNotFound'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const formattedStickerName = getFormattedStickerName(sticker);
+  const currentRating = resolveStickerNsfw(sticker, sticker.pack);
+  await interaction.showModal({
+    customId: `${BotModalId.PUBLISH_EDIT_STICKER}:${sticker.id}`,
+    title: t('commands.publish-imported-pack.components.editModalTitle', { name: formattedStickerName }),
+    components: [
+      {
+        type: ComponentType.TextDisplay,
+        content: t('commands.publish-imported-pack.components.editingModalText', {
+          name: `\`${formattedStickerName}\``,
+          pack: getFormattedPackName(sticker.pack),
+        }),
+      },
+      {
+        type: ComponentType.Label,
+        label: t('commands.publish-imported-pack.components.nameLabel'),
+        description: t('commands.publish-imported-pack.components.nameDescription'),
+        component: {
+          type: ComponentType.TextInput,
+          customId: PublishEditStickerModalCustomIds.NEW_NAME_INPUT,
+          style: TextInputStyle.Short,
+          minLength: stickerNameOptionMeta.min_length,
+          maxLength: stickerNameOptionMeta.max_length,
+          required: true,
+          // Discord rejects an explicit empty-string value; omit it entirely for
+          // freshly-imported stickers that don't have a name yet
+          value: sticker.name || undefined,
+        } as TextInputComponentData,
+      },
+      {
+        type: ComponentType.Label,
+        label: t('commands.publish-imported-pack.components.ratingChoiceLabel'),
+        description: t('commands.publish-imported-pack.components.ratingChoiceDescription'),
+        component: {
+          type: ComponentType.RadioGroup,
+          customId: PublishEditStickerModalCustomIds.RATING_INPUT,
+          options: [
+            {
+              value: PublishRatingOption.SFW,
+              label: t('commands.publish-imported-pack.components.ratingSfwLabel'),
+              description: t('commands.publish-imported-pack.components.ratingSfwDescription'),
+              default: !currentRating,
+            },
+            {
+              value: PublishRatingOption.NSFW,
+              label: t('commands.publish-imported-pack.components.ratingNsfwLabel'),
+              description: t('commands.publish-imported-pack.components.ratingNsfwDescription'),
+              default: currentRating,
+            },
+          ],
+        } as unknown as ComponentInLabelData,
+      },
+    ],
+  });
+};
+
+export const publishStepComponentHandler = (direction: 'prev' | 'next'): BotMessageComponentHandler => async (interaction, context, resourceId) => {
+  if (!interaction.isButton()) {
+    throw new Error('Button interaction expected');
+  }
+
+  const { t, db } = context;
+  const user = await updateOrCreateUser(context, interaction);
+  if (user.readOnly) {
+    await interactionReply(context, interaction, {
+      content: t('commands.global.responses.noPermission'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const sticker = resourceId ? await db.sticker.findUnique({
+    where: { id: resourceId, deletedAt: null, createdBy: user.id },
+    include: { pack: { include: { telegramPack: true } } },
+  }) : null;
+
+  if (!sticker) {
+    await interactionReply(context, interaction, {
+      content: t('commands.publish-imported-pack.responses.stickerNotFound'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const nextContent = await getPublishStepContent({
+    t,
+    db,
+    pack: sticker.pack,
+    currentStickerId: sticker.id,
+    direction,
+  });
+  await interaction.update({ flags: MessageFlags.IsComponentsV2, ...nextContent });
+};
+
+export const publishJumpInvalidComponentHandler: BotMessageComponentHandler = async (interaction, context, resourceId) => {
+  if (!interaction.isButton()) {
+    throw new Error('Button interaction expected');
+  }
+
+  const { t, db } = context;
+  const user = await updateOrCreateUser(context, interaction);
+  if (user.readOnly) {
+    await interactionReply(context, interaction, {
+      content: t('commands.global.responses.noPermission'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const pack = resourceId ? await db.pack.findFirst({
+    where: { id: resourceId, deletedAt: null, createdBy: user.id, telegramPackId: { not: null } },
+    include: { telegramPack: true },
+  }) : null;
+
+  if (!pack) {
+    await interactionReply(context, interaction, {
+      content: t('commands.publish-imported-pack.responses.packNotFound'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const nextContent = await getPublishJumpToInvalidContent({ t, db, pack });
+  await interaction.update({ flags: MessageFlags.IsComponentsV2, ...nextContent });
+};
+
+export const publishConfirmComponentHandler: BotMessageComponentHandler = async (interaction, context, resourceId) => {
+  if (!interaction.isButton()) {
+    throw new Error('Button interaction expected');
+  }
+
+  const { t, db } = context;
+  const user = await updateOrCreateUser(context, interaction);
+  if (user.readOnly) {
+    await interactionReply(context, interaction, {
+      content: t('commands.global.responses.noPermission'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  let pack = resourceId ? await db.pack.findFirst({
+    where: { id: resourceId, deletedAt: null, createdBy: user.id, telegramPackId: { not: null } },
+    include: { telegramPack: true },
+  }) : null;
+
+  if (!pack) {
+    await interactionReply(context, interaction, {
+      content: t('commands.publish-imported-pack.responses.packNotFound'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  if (pack.public) {
+    await interactionReply(context, interaction, {
+      content: t('commands.publish-imported-pack.responses.alreadyPublished'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  // Never trust the disabled-button client state — re-validate every sticker server-side
+  const stickers = await findOrderedPackStickers(db, pack);
+  if (stickers.length === 0 || !stickers.every(isStickerPublishReady)) {
+    await interactionReply(context, interaction, {
+      content: t('commands.publish-imported-pack.responses.notReady'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  // Race safety net; the DB also enforces this with a partial unique index
+  const existingPublishedPack = await db.pack.findFirst({
+    where: { telegramPackId: pack.telegramPackId, public: true, deletedAt: null },
+  });
+  if (existingPublishedPack) {
+    await interactionReply(context, interaction, {
+      content: t('commands.publish-imported-pack.responses.alreadyPublishedElsewhere', {
+        user: userMention(String(existingPublishedPack.createdBy)),
+      }),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const packSnapshot: PackSnapshot = {
+    name: getPackDisplayName(pack),
+    public: pack.public,
+    nsfw: pack.nsfw,
+  };
+  // The pack's own rating is derived from its stickers: it's only NSFW if every
+  // single sticker was explicitly marked NSFW; even one SFW sticker makes it SFW
+  const nsfwStickerCount = stickers.filter(sticker => sticker.nsfwOverride === true).length;
+  const packNsfw = nsfwStickerCount === stickers.length;
+  pack = await db.pack.update({
+    where: { id: pack.id },
+    data: { public: true, nsfw: packNsfw },
+    include: { telegramPack: true },
+  });
+
+  const ratingNote = packNsfw
+    ? t('commands.publish-imported-pack.responses.publishedRatingAllNsfw')
+    : nsfwStickerCount > 0
+      ? t('commands.publish-imported-pack.responses.publishedRatingMixed', { count: nsfwStickerCount })
+      : t('commands.publish-imported-pack.responses.publishedRatingAllSfw');
+  await interactionReply(context, interaction, {
+    content: [
+      t('commands.publish-imported-pack.responses.published', { name: `\`${getFormattedPackName(pack)}\`` }),
+      ratingNote,
+    ].join('\n'),
+    flags: MessageFlags.Ephemeral,
+  });
+
+  await postPackToFeed({
+    context,
+    interaction,
+    pack,
+    action: 'edit',
+    snapshot: packSnapshot,
+  });
+};

--- a/src/components/component-handlers/sticker-button.component-handler.ts
+++ b/src/components/component-handlers/sticker-button.component-handler.ts
@@ -84,7 +84,7 @@ export const stickerButtonComponentHandler = (deleteOnly: boolean): BotMessageCo
       },
       deletedAt: null,
     },
-    include: { telegramSticker: true },
+    include: { telegramSticker: true, pack: true },
   });
 
   const updateData: StickerMessageUpdateInput = {};

--- a/src/components/publish-confirm.component.ts
+++ b/src/components/publish-confirm.component.ts
@@ -1,0 +1,13 @@
+import { BotMessageComponent, BotMessageComponentCustomId } from '../types/bot-interaction.js';
+import {
+  publishConfirmComponentDefinition,
+} from './component-definitions/publish.component-definition.js';
+import {
+  publishConfirmComponentHandler,
+} from './component-handlers/publish.component-handler.js';
+
+export const publishConfirmComponent: BotMessageComponent = {
+  id: BotMessageComponentCustomId.PUBLISH_CONFIRM,
+  getDefinition: publishConfirmComponentDefinition,
+  handle: publishConfirmComponentHandler,
+};

--- a/src/components/publish-jump-invalid.component.ts
+++ b/src/components/publish-jump-invalid.component.ts
@@ -1,0 +1,13 @@
+import { BotMessageComponent, BotMessageComponentCustomId } from '../types/bot-interaction.js';
+import {
+  publishJumpInvalidComponentDefinition,
+} from './component-definitions/publish.component-definition.js';
+import {
+  publishJumpInvalidComponentHandler,
+} from './component-handlers/publish.component-handler.js';
+
+export const publishJumpInvalidComponent: BotMessageComponent = {
+  id: BotMessageComponentCustomId.PUBLISH_JUMP_INVALID,
+  getDefinition: publishJumpInvalidComponentDefinition,
+  handle: publishJumpInvalidComponentHandler,
+};

--- a/src/components/publish-next.component.ts
+++ b/src/components/publish-next.component.ts
@@ -1,0 +1,13 @@
+import { BotMessageComponent, BotMessageComponentCustomId } from '../types/bot-interaction.js';
+import {
+  publishNextComponentDefinition,
+} from './component-definitions/publish.component-definition.js';
+import {
+  publishStepComponentHandler,
+} from './component-handlers/publish.component-handler.js';
+
+export const publishNextComponent: BotMessageComponent = {
+  id: BotMessageComponentCustomId.PUBLISH_NEXT,
+  getDefinition: publishNextComponentDefinition,
+  handle: publishStepComponentHandler('next'),
+};

--- a/src/components/publish-open.component.ts
+++ b/src/components/publish-open.component.ts
@@ -1,0 +1,13 @@
+import { BotMessageComponent, BotMessageComponentCustomId } from '../types/bot-interaction.js';
+import {
+  publishOpenComponentDefinition,
+} from './component-definitions/publish.component-definition.js';
+import {
+  publishOpenComponentHandler,
+} from './component-handlers/publish.component-handler.js';
+
+export const publishOpenComponent: BotMessageComponent = {
+  id: BotMessageComponentCustomId.PUBLISH_OPEN,
+  getDefinition: publishOpenComponentDefinition,
+  handle: publishOpenComponentHandler,
+};

--- a/src/components/publish-prev.component.ts
+++ b/src/components/publish-prev.component.ts
@@ -1,0 +1,13 @@
+import { BotMessageComponent, BotMessageComponentCustomId } from '../types/bot-interaction.js';
+import {
+  publishPrevComponentDefinition,
+} from './component-definitions/publish.component-definition.js';
+import {
+  publishStepComponentHandler,
+} from './component-handlers/publish.component-handler.js';
+
+export const publishPrevComponent: BotMessageComponent = {
+  id: BotMessageComponentCustomId.PUBLISH_PREV,
+  getDefinition: publishPrevComponentDefinition,
+  handle: publishStepComponentHandler('prev'),
+};

--- a/src/constants/emoji-characters.ts
+++ b/src/constants/emoji-characters.ts
@@ -6,6 +6,7 @@ export enum EmojiCharacters {
   GREEN_SQUARE = '🟩',
   RED_SQUARE = '🟥',
   GREEN_CHECK = '✅',
+  CROSS_MARK = '❌',
   INFO = 'ℹ️',
   NO_ONE_UNDER_18 = '🔞',
   LOCKED = '🔒',
@@ -16,6 +17,7 @@ export enum EmojiCharacters {
   SKIP_BACK = '⏮️',
   SKIP_FORWARD = '⏭️',
   PENCIL = '✏️',
+  ROCKET = '🚀',
   // Reserved for imported pack names, must not appear in user-provided names
   PAPER_PLANE = '⌲',
 }

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -176,7 +176,15 @@
         "newUrlDescription": "Enter a new URL to change the sticker image. Leave blank to keep the image unchanged.",
         "importedStickerNote": "This sticker was imported from Telegram, so its emojis, position and image are managed by the import and cannot be changed here.",
         "importedNameLabel": "Sticker name (optional)",
-        "importedNameDescription": "Optional name to make this sticker easier to find. Leave blank to search only by emoji and position."
+        "importedNameDescription": "Optional name to make this sticker easier to find. Leave blank to search only by emoji and position.",
+        "ratingChoiceLabel": "Sticker content rating",
+        "ratingChoiceDescription": "Overrides the pack's content rating for this sticker only.",
+        "ratingDefaultLabel": "Pack default",
+        "ratingDefaultDescription": "Use the pack's own content rating for this sticker",
+        "ratingSfwLabel": "Safe for all audiences",
+        "ratingSfwDescription": "Always treat this sticker as safe for all audiences, even in an age-restricted pack",
+        "ratingNsfwLabel": "Age-restricted (NSFW)",
+        "ratingNsfwDescription": "Always treat this sticker as age-restricted, even in a safe-for-all-audiences pack"
       },
       "options": {
         "name": {
@@ -217,7 +225,9 @@
       },
       "components": {
         "editPackModalTitle": "Edit pack {{name}}",
-        "importedNameNote": "This pack was imported from Telegram: its name is managed by the import and cannot be changed here, and imported packs always stay private. Re-run the import to refresh the name.",
+        "importedNameNote": "This pack was imported from Telegram: its name is managed by the import and cannot be changed here. Re-run the import to refresh the name.",
+        "importedUnpublishedNote": "This pack hasn't been published yet, so it stays private to you. Use /publish-imported-pack once every sticker has a name and rating to make it the public, canonical copy.",
+        "publicFalseDescriptionImported": "Only you can see and use it. Publish again anytime with /publish-imported-pack.",
         "nameLabel": "Pack name",
         "nameDescription": "Enter a unique name for the sticker pack. Two packs cannot have the same name within the app.",
         "publicChoiceLabel": "Pack visibility",
@@ -294,6 +304,52 @@
         "start": {
           "name": "start",
           "description": "Position of the sticker to start from (defaults to 1, the first sticker)"
+        }
+      }
+    },
+    "publish-imported-pack": {
+      "name": "publish-imported-pack",
+      "description": "Publish your copy of an imported Telegram pack as the public, canonical version",
+      "responses": {
+        "packNotFound": "The specified pack could not be found, or it is not an imported pack you own",
+        "emptyPack": "The specified pack does not contain any stickers",
+        "stickerNotFound": "The specified sticker could not be found",
+        "alreadyPublished": "This pack has already been published",
+        "alreadyPublishedElsewhere": "This Telegram pack has already been published by {{user}}. Ask them to make changes, or use {{user}}'s copy with /pack instead.",
+        "notReady": "Not every sticker in this pack has a name and an explicit content rating yet. Please review them all before publishing.",
+        "published": "The pack {{name}} is now public. Everyone can now see and use it, and anyone importing it fresh will see your names and ratings as the default.",
+        "publishedRatingAllSfw": "**Rating:** 🌐 Safe for all audiences",
+        "publishedRatingAllNsfw": "**Rating:** 🔞 Age-restricted (NSFW), meaning every sticker in this pack is age-restricted and can only be used in age-restricted channels and DMs via /nsfw-pack and /nsfw-sticker.",
+        "publishedRatingMixed": "**Rating:** 🌐 Safe for all audiences overall, but {{count}} sticker(s) inside are individually marked age-restricted (NSFW) and can still only be used in age-restricted channels and DMs via /nsfw-pack and /nsfw-sticker."
+      },
+      "components": {
+        "reviewingText": "Reviewing stickers in pack {{pack}}\nSticker {{position}} of {{total}}{{identifier}}",
+        "currentNameText": "Current name: {{name}}",
+        "currentRatingText": "Current rating: {{rating}}",
+        "ratingUnset": "_(not set)_",
+        "criteriaNameLabel": "Has a short, accurate name",
+        "criteriaRatingLabel": "Has an explicit content rating",
+        "editingModalText": "You are editing sticker {{name}} from pack {{pack}}.",
+        "nameLabel": "Sticker name",
+        "nameDescription": "Enter a short, accurate English name for this sticker",
+        "ratingChoiceLabel": "Content rating",
+        "ratingChoiceDescription": "Choose an explicit rating for this sticker. This cannot be left as \"pack default\" before publishing.",
+        "ratingSfwLabel": "Safe for all audiences",
+        "ratingSfwDescription": "This sticker is safe to show anywhere",
+        "ratingNsfwLabel": "Age-restricted (NSFW)",
+        "ratingNsfwDescription": "This sticker will only be usable in age-restricted channels and DMs",
+        "editButton": "Edit",
+        "previousButton": "Previous",
+        "nextButton": "Next",
+        "publishButton": "Publish",
+        "jumpToInvalidButton": "Jump to first invalid sticker",
+        "editModalTitle": "Edit sticker {{name}}",
+        "allDoneText": "All stickers in pack {{pack}} have been shown"
+      },
+      "options": {
+        "pack": {
+          "name": "pack",
+          "description": "The imported pack you want to publish"
         }
       }
     },

--- a/src/locales/hu/translation.json
+++ b/src/locales/hu/translation.json
@@ -163,7 +163,15 @@
         "newFileLabel": "Matricafájl frissítése",
         "newFileDescription": "Tölts fel egy új fájlt a matrica kép lecseréléséhez. Ha nem szeretnéd megváltoztatni, hagyd üresen.",
         "newUrlLabel": "Matrica URL frissítése",
-        "newUrlDescription": "Adj meg egy új URL-t a matrica kép lecseréléséhez. Ha nem szeretnéd megváltoztatni, hagyd üresen."
+        "newUrlDescription": "Adj meg egy új URL-t a matrica kép lecseréléséhez. Ha nem szeretnéd megváltoztatni, hagyd üresen.",
+        "ratingChoiceLabel": "Matrica tartalmi besorolása",
+        "ratingChoiceDescription": "Felülbírálja a csomag tartalmi besorolását, kizárólag ennél a matricánál.",
+        "ratingDefaultLabel": "Csomag alapértelmezés",
+        "ratingDefaultDescription": "A csomag saját tartalmi besorolásának használata ennél a matricánál",
+        "ratingSfwLabel": "Mindenki számára biztonságos",
+        "ratingSfwDescription": "Ez a matrica mindig biztonságosnak minősül, még korhatáros csomagban is",
+        "ratingNsfwLabel": "Korhatáros (NSFW)",
+        "ratingNsfwDescription": "Ez a matrica mindig korhatárosnak minősül, még mindenki számára biztonságos csomagban is"
       },
       "options": {
         "name": {

--- a/src/options/publish-imported-pack.options.ts
+++ b/src/options/publish-imported-pack.options.ts
@@ -1,0 +1,17 @@
+import { APIApplicationCommandOption } from 'discord-api-types/v10';
+import { TFunction } from 'i18next';
+import { BotChatInputCommandName } from '../types/bot-interaction.js';
+import { PublishImportedPackCommandOptionName } from '../types/localization.js';
+import { getCommonOptionMeta } from '../utils/get-common-option-meta.js';
+import { getGlobalOptions } from './global.options.js';
+import { packNameOptionMeta } from './metadata/pack-name.option-meta.js';
+
+export const getPublishImportedPackOptions = (t: TFunction): APIApplicationCommandOption[] => [
+  {
+    ...getCommonOptionMeta(t, BotChatInputCommandName.PUBLISH_IMPORTED_PACK, PublishImportedPackCommandOptionName.PACK),
+    required: true,
+    autocomplete: true,
+    ...packNameOptionMeta,
+  },
+  ...getGlobalOptions(t),
+];

--- a/src/types/bot-interaction.ts
+++ b/src/types/bot-interaction.ts
@@ -27,6 +27,7 @@ export const enum BotChatInputCommandName {
   EDIT_PACK = 'edit-pack',
   REORDER_STICKER = 'reorder-sticker',
   MASS_RENAME_STICKERS = 'mass-rename-stickers',
+  PUBLISH_IMPORTED_PACK = 'publish-imported-pack',
 }
 
 export const enum BotMessageContextMenuCommandName {
@@ -42,6 +43,7 @@ export const enum BotModalId {
   DELETE_PACK = 'deletePackModal',
   EDIT_PACK = 'editPackModal',
   MASS_RENAME_STICKER = 'massRenameStickerModal',
+  PUBLISH_EDIT_STICKER = 'publishEditStickerModal',
 }
 
 export const enum BotMessageComponentCustomId {
@@ -54,6 +56,11 @@ export const enum BotMessageComponentCustomId {
   MASS_RENAME_OPEN = 'mass-rename-open',
   MASS_RENAME_PREV = 'mass-rename-prev',
   MASS_RENAME_NEXT = 'mass-rename-next',
+  PUBLISH_OPEN = 'publish-open',
+  PUBLISH_PREV = 'publish-prev',
+  PUBLISH_NEXT = 'publish-next',
+  PUBLISH_CONFIRM = 'publish-confirm',
+  PUBLISH_JUMP_INVALID = 'publish-jump-invalid',
 }
 
 export type CommandHandler = FrameworkCommandHandler<UserInteractionContext>;

--- a/src/types/localization.ts
+++ b/src/types/localization.ts
@@ -49,6 +49,10 @@ export const enum MassRenameStickersCommandOptionName {
   START = 'start',
 }
 
+export const enum PublishImportedPackCommandOptionName {
+  PACK = 'pack',
+}
+
 interface CommandOptionsMap {
   [BotChatInputCommandName.STICKER]: StickerCommandOptionName,
   [BotChatInputCommandName.NSFW_STICKER]: StickerCommandOptionName,
@@ -62,6 +66,7 @@ interface CommandOptionsMap {
   [BotChatInputCommandName.EDIT_PACK]: EditPackCommandOptionName,
   [BotChatInputCommandName.REORDER_STICKER]: ReorderStickerCommandOptionName,
   [BotChatInputCommandName.MASS_RENAME_STICKERS]: MassRenameStickersCommandOptionName,
+  [BotChatInputCommandName.PUBLISH_IMPORTED_PACK]: PublishImportedPackCommandOptionName,
 }
 
 export const enum GlobalCommandResponse {
@@ -163,6 +168,19 @@ export const enum MassRenameStickersCommandResponse {
   stickerNotFound = 'stickerNotFound',
 }
 
+export const enum PublishImportedPackCommandResponse {
+  packNotFound = 'packNotFound',
+  emptyPack = 'emptyPack',
+  stickerNotFound = 'stickerNotFound',
+  alreadyPublished = 'alreadyPublished',
+  alreadyPublishedElsewhere = 'alreadyPublishedElsewhere',
+  notReady = 'notReady',
+  published = 'published',
+  publishedRatingAllSfw = 'publishedRatingAllSfw',
+  publishedRatingAllNsfw = 'publishedRatingAllNsfw',
+  publishedRatingMixed = 'publishedRatingMixed',
+}
+
 interface CommandResponsesMap {
   global: GlobalCommandResponse,
   [BotChatInputCommandName.STICKER]: StickerCommandResponse,
@@ -176,6 +194,7 @@ interface CommandResponsesMap {
   [BotChatInputCommandName.EDIT_PACK]: EditPackCommandResponse,
   [BotChatInputCommandName.REORDER_STICKER]: ReorderStickerCommandResponse,
   [BotChatInputCommandName.MASS_RENAME_STICKERS]: MassRenameStickersCommandResponse,
+  [BotChatInputCommandName.PUBLISH_IMPORTED_PACK]: PublishImportedPackCommandResponse,
 }
 
 interface ComponentsMap {
@@ -213,6 +232,14 @@ interface ComponentsMap {
     'importedStickerNote',
     'importedNameLabel',
     'importedNameDescription',
+    'ratingChoiceLabel',
+    'ratingChoiceDescription',
+    'ratingDefaultLabel',
+    'ratingDefaultDescription',
+    'ratingSfwLabel',
+    'ratingSfwDescription',
+    'ratingNsfwLabel',
+    'ratingNsfwDescription',
   ],
   [BotChatInputCommandName.DELETE_STICKER]: [
     'deleteStickerModalTitle',
@@ -248,6 +275,7 @@ interface ComponentsMap {
   [BotChatInputCommandName.EDIT_PACK]: [
     'editPackModalTitle',
     'importedNameNote',
+    'importedUnpublishedNote',
     'nameLabel',
     'nameDescription',
     'publicChoiceLabel',
@@ -256,6 +284,7 @@ interface ComponentsMap {
     'publicTrueDescription',
     'publicFalseLabel',
     'publicFalseDescription',
+    'publicFalseDescriptionImported',
     'nsfwChoiceLabel',
     'nsfwChoiceDescription',
     'nsfwTrueLabel',
@@ -271,6 +300,30 @@ interface ComponentsMap {
     'previousButton',
     'nextButton',
     'renameModalTitle',
+    'allDoneText',
+  ],
+  [BotChatInputCommandName.PUBLISH_IMPORTED_PACK]: [
+    'reviewingText',
+    'currentNameText',
+    'currentRatingText',
+    'ratingUnset',
+    'criteriaNameLabel',
+    'criteriaRatingLabel',
+    'editingModalText',
+    'nameLabel',
+    'nameDescription',
+    'ratingChoiceLabel',
+    'ratingChoiceDescription',
+    'ratingSfwLabel',
+    'ratingSfwDescription',
+    'ratingNsfwLabel',
+    'ratingNsfwDescription',
+    'editButton',
+    'previousButton',
+    'nextButton',
+    'publishButton',
+    'jumpToInvalidButton',
+    'editModalTitle',
     'allDoneText',
   ],
 }

--- a/src/utils/autocomplete/pack-name.autocomplete.ts
+++ b/src/utils/autocomplete/pack-name.autocomplete.ts
@@ -6,14 +6,18 @@ import { truncateToMaximumLength } from '../messaging.js';
 interface PackNameAutocompleteOptions {
   nsfw?: boolean;
   ownedOnly?: boolean;
+  importedOnly?: boolean;
 }
 
-export const getPackNameAutocompleteHandler = ({ nsfw = false, ownedOnly = false }: PackNameAutocompleteOptions = {}): AutocompleteHandler => async (interaction, context, optionName) => {
+export const getPackNameAutocompleteHandler = ({ nsfw = false, ownedOnly = false, importedOnly = false }: PackNameAutocompleteOptions = {}): AutocompleteHandler => async (interaction, context, optionName) => {
   const value = interaction.options.getString(optionName, true).trim().toLowerCase();
   const availablePacks = await findAvailableStickerPacks(context, interaction, nsfw);
-  const packs = ownedOnly
+  const scopedPacks = ownedOnly
     ? availablePacks.filter(pack => !pack.public || pack.createdBy === BigInt(interaction.user.id))
     : availablePacks;
+  const packs = importedOnly
+    ? scopedPacks.filter(pack => pack.telegramPack !== null)
+    : scopedPacks;
   if (packs.length === 0) {
     await interaction.respond([]);
     return;

--- a/src/utils/get-mass-rename-content.ts
+++ b/src/utils/get-mass-rename-content.ts
@@ -6,8 +6,9 @@ import { Pack, PrismaClient, Sticker, TelegramSticker } from '../generated/prism
 import { BotMessageComponentCustomId } from '../types/bot-interaction.js';
 import { FormattablePack, getFormattedPackName } from './get-formatted-pack-name.js';
 import { mapStickersToGalleryItems } from './map-stickers-to-gallery-items.js';
+import { resolveStickerNsfw } from './resolve-sticker-nsfw.js';
 
-export type MassRenamePack = Pick<Pack, 'id' | 'telegramPackId'> & FormattablePack;
+export type MassRenamePack = Pick<Pack, 'id' | 'telegramPackId' | 'nsfw'> & FormattablePack;
 
 export const findOrderedPackStickers = (db: PrismaClient, pack: Pick<Pack, 'id' | 'telegramPackId'>) => db.sticker.findMany({
   where: { deletedAt: null, packId: pack.id },
@@ -25,7 +26,7 @@ interface GetMassRenameStickerContentOptions {
 }
 
 export const getMassRenameStickerContent = ({ t, pack, sticker, index, total }: GetMassRenameStickerContentOptions) => {
-  const { files, items } = mapStickersToGalleryItems([sticker], pack.nsfw);
+  const { files, items } = mapStickersToGalleryItems([sticker], resolveStickerNsfw(sticker, pack));
 
   // Imported stickers are identified by their emoji and position on the position line;
   // the current name (if any) gets its own line for both sticker types

--- a/src/utils/get-pack-preview-content.ts
+++ b/src/utils/get-pack-preview-content.ts
@@ -8,21 +8,26 @@ import { BotMessageComponentCustomId } from '../types/bot-interaction.js';
 import { FormattablePack, getFormattedPackName } from './get-formatted-pack-name.js';
 import { StickerUrlSource } from './get-sticker-url.js';
 import { mapStickersToGalleryItems } from './map-stickers-to-gallery-items.js';
+import { resolveStickerNsfw } from './resolve-sticker-nsfw.js';
 
 export const packItemsPerPage = 9;
 
 interface GetPackPreviewContentOptions {
   t: TFunction;
-  pack: Pick<Pack, 'id'> & FormattablePack & {
+  pack: Pick<Pack, 'id' | 'nsfw'> & FormattablePack & {
     telegramPack: Pick<TelegramPack, 'title' | 'telegramPackName'> | null;
   };
-  stickers: (Pick<Sticker, 'description'> & StickerUrlSource)[];
+  stickers: (Pick<Sticker, 'description' | 'nsfwOverride'> & StickerUrlSource)[];
   page: number;
   totalPages: number;
+  // Whether this preview was opened via the NSFW-flagged command variant (e.g. /nsfw-pack);
+  // carried through the pagination buttons' custom IDs so paging stays consistent
+  nsfw: boolean;
 }
 
-export const getPackPreviewContent = ({ t, pack, stickers, page, totalPages }: GetPackPreviewContentOptions) => {
-  const { files, items } = mapStickersToGalleryItems(stickers);
+export const getPackPreviewContent = ({ t, pack, stickers, page, totalPages, nsfw }: GetPackPreviewContentOptions) => {
+  const { files, items } = mapStickersToGalleryItems(stickers, stickers.map(sticker => resolveStickerNsfw(sticker, pack)));
+  const pageButtonSuffix = `${pack.id}:${page}:${nsfw ? 1 : 0}`;
 
   const components: APIMessageTopLevelComponent[] = [
     {
@@ -53,7 +58,7 @@ export const getPackPreviewContent = ({ t, pack, stickers, page, totalPages }: G
       components: [
         {
           type: ComponentType.Button,
-          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_FIRST}:${pack.id}:${page}`,
+          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_FIRST}:${pageButtonSuffix}`,
           label: t('commands.pack.components.firstPageButton'),
           style: ButtonStyle.Secondary,
           emoji: { name: EmojiCharacters.SKIP_BACK },
@@ -61,7 +66,7 @@ export const getPackPreviewContent = ({ t, pack, stickers, page, totalPages }: G
         },
         {
           type: ComponentType.Button,
-          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_PREV}:${pack.id}:${page}`,
+          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_PREV}:${pageButtonSuffix}`,
           label: t('commands.pack.components.previousPageButton'),
           style: ButtonStyle.Secondary,
           emoji: { name: EmojiCharacters.ARROW_LEFT },
@@ -76,7 +81,7 @@ export const getPackPreviewContent = ({ t, pack, stickers, page, totalPages }: G
         },
         {
           type: ComponentType.Button,
-          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_NEXT}:${pack.id}:${page}`,
+          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_NEXT}:${pageButtonSuffix}`,
           label: t('commands.pack.components.nextPageButton'),
           style: ButtonStyle.Secondary,
           emoji: { name: EmojiCharacters.ARROW_RIGHT },
@@ -84,7 +89,7 @@ export const getPackPreviewContent = ({ t, pack, stickers, page, totalPages }: G
         },
         {
           type: ComponentType.Button,
-          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_LAST}:${pack.id}:${page}`,
+          custom_id: `${BotMessageComponentCustomId.PACK_PAGE_LAST}:${pageButtonSuffix}`,
           label: t('commands.pack.components.lastPageButton'),
           style: ButtonStyle.Secondary,
           emoji: { name: EmojiCharacters.SKIP_FORWARD },

--- a/src/utils/get-publish-pack-content.ts
+++ b/src/utils/get-publish-pack-content.ts
@@ -1,0 +1,207 @@
+import { APIButtonComponent, ButtonStyle, ComponentType } from 'discord-api-types/v10';
+import { APIMessageTopLevelComponent } from 'discord.js';
+import { TFunction } from 'i18next';
+import { EmojiCharacters } from '../constants/emoji-characters.js';
+import { Pack, PrismaClient, Sticker, TelegramSticker } from '../generated/prisma/client.js';
+import {
+  stickerNameInvalidPattern,
+  stickerNameOptionMeta,
+} from '../options/metadata/sticker-name.option-meta.js';
+import { BotMessageComponentCustomId } from '../types/bot-interaction.js';
+import { findOrderedPackStickers } from './get-mass-rename-content.js';
+import { FormattablePack, getFormattedPackName } from './get-formatted-pack-name.js';
+import { mapStickersToGalleryItems } from './map-stickers-to-gallery-items.js';
+
+export type PublishPack = Pick<Pack, 'id' | 'telegramPackId' | 'nsfw'> & FormattablePack;
+
+export const isStickerNamePublishReady = (name: string) => (
+  name.length >= stickerNameOptionMeta.min_length
+  && name.length <= stickerNameOptionMeta.max_length
+  && !name.match(stickerNameInvalidPattern)
+  && !name.includes(EmojiCharacters.PAPER_PLANE)
+);
+
+export const isStickerRatingPublishReady = (sticker: Pick<Sticker, 'nsfwOverride'>) => sticker.nsfwOverride !== null;
+
+// A sticker is ready to publish once it has a real, valid name and an explicit
+// (non-"pack default") content rating
+export const isStickerPublishReady = (sticker: Pick<Sticker, 'name' | 'nsfwOverride'>) => (
+  isStickerNamePublishReady(sticker.name) && isStickerRatingPublishReady(sticker)
+);
+
+const formatRating = (t: TFunction, nsfwOverride: boolean | null) => {
+  if (nsfwOverride === null) return t('commands.publish-imported-pack.components.ratingUnset');
+  return nsfwOverride
+    ? t('commands.publish-imported-pack.components.ratingNsfwLabel')
+    : t('commands.publish-imported-pack.components.ratingSfwLabel');
+};
+
+const getPublishActionRow = (t: TFunction, pack: PublishPack, allReady: boolean): APIMessageTopLevelComponent => {
+  const components: APIButtonComponent[] = [
+    {
+      type: ComponentType.Button,
+      custom_id: `${BotMessageComponentCustomId.PUBLISH_CONFIRM}:${pack.id}`,
+      label: t('commands.publish-imported-pack.components.publishButton'),
+      style: ButtonStyle.Success,
+      emoji: { name: EmojiCharacters.ROCKET },
+      disabled: !allReady,
+    },
+  ];
+  // Lets the publisher jump straight to the sticker blocking publish instead of
+  // stepping through every sticker one by one to find it
+  if (!allReady) {
+    components.push({
+      type: ComponentType.Button,
+      custom_id: `${BotMessageComponentCustomId.PUBLISH_JUMP_INVALID}:${pack.id}`,
+      label: t('commands.publish-imported-pack.components.jumpToInvalidButton'),
+      style: ButtonStyle.Secondary,
+    });
+  }
+  return { type: ComponentType.ActionRow, components };
+};
+
+interface GetPublishStickerContentOptions {
+  t: TFunction;
+  pack: PublishPack;
+  sticker: Sticker & { telegramSticker: TelegramSticker | null };
+  index: number;
+  total: number;
+  allReady: boolean;
+}
+
+export const getPublishStickerContent = ({ t, pack, sticker, index, total, allReady }: GetPublishStickerContentOptions) => {
+  // The publisher is reviewing and rating these images themselves, so never spoiler
+  // them here regardless of the sticker's resolved rating
+  const { files, items } = mapStickersToGalleryItems([sticker], false);
+
+  const nameReady = isStickerNamePublishReady(sticker.name);
+  const ratingReady = isStickerRatingPublishReady(sticker);
+
+  const stickerIdentifier = sticker.telegramSticker !== null
+    ? `: \`${sticker.telegramSticker.emoji}#${sticker.telegramSticker.order + 1}\``
+    : '';
+
+  const components: APIMessageTopLevelComponent[] = [
+    {
+      type: ComponentType.TextDisplay,
+      content: [
+        t('commands.publish-imported-pack.components.reviewingText', {
+          pack: getFormattedPackName(pack),
+          position: index + 1,
+          total,
+          identifier: stickerIdentifier,
+        }),
+        t('commands.publish-imported-pack.components.currentNameText', {
+          name: sticker.name ? `\`${sticker.name}\`` : t('commands.publish-imported-pack.components.ratingUnset'),
+        }),
+        t('commands.publish-imported-pack.components.currentRatingText', {
+          rating: formatRating(t, sticker.nsfwOverride),
+        }),
+        `${nameReady ? EmojiCharacters.GREEN_CHECK : EmojiCharacters.CROSS_MARK} ${t('commands.publish-imported-pack.components.criteriaNameLabel')}`,
+        `${ratingReady ? EmojiCharacters.GREEN_CHECK : EmojiCharacters.CROSS_MARK} ${t('commands.publish-imported-pack.components.criteriaRatingLabel')}`,
+      ].join('\n'),
+    },
+    {
+      type: ComponentType.MediaGallery,
+      items,
+    },
+    {
+      type: ComponentType.ActionRow,
+      components: [
+        {
+          type: ComponentType.Button,
+          custom_id: `${BotMessageComponentCustomId.PUBLISH_PREV}:${sticker.id}`,
+          label: t('commands.publish-imported-pack.components.previousButton'),
+          style: ButtonStyle.Secondary,
+          emoji: { name: EmojiCharacters.ARROW_LEFT },
+          disabled: index <= 0,
+        },
+        {
+          type: ComponentType.Button,
+          custom_id: `${BotMessageComponentCustomId.PUBLISH_OPEN}:${sticker.id}`,
+          label: t('commands.publish-imported-pack.components.editButton'),
+          style: ButtonStyle.Primary,
+          emoji: { name: EmojiCharacters.PENCIL },
+        },
+        {
+          type: ComponentType.Button,
+          custom_id: `${BotMessageComponentCustomId.PUBLISH_NEXT}:${sticker.id}`,
+          label: t('commands.publish-imported-pack.components.nextButton'),
+          style: ButtonStyle.Secondary,
+          emoji: { name: EmojiCharacters.ARROW_RIGHT },
+        },
+      ],
+    },
+    getPublishActionRow(t, pack, allReady),
+  ];
+
+  return { components, files };
+};
+
+export const getPublishDoneContent = (t: TFunction, pack: PublishPack, allReady: boolean) => ({
+  components: [
+    {
+      type: ComponentType.TextDisplay,
+      content: `${EmojiCharacters.GREEN_CHECK} ${t('commands.publish-imported-pack.components.allDoneText', {
+        pack: getFormattedPackName(pack),
+      })}`,
+    },
+    getPublishActionRow(t, pack, allReady),
+  ] as APIMessageTopLevelComponent[],
+  files: [],
+});
+
+interface GetPublishStepContentOptions {
+  t: TFunction;
+  db: PrismaClient;
+  pack: PublishPack;
+  currentStickerId: string;
+  direction: 'prev' | 'next';
+}
+
+// Builds the message content for the sticker before/after the current one, or the
+// completion text once the end of the pack is reached
+export const getPublishStepContent = async ({ t, db, pack, currentStickerId, direction }: GetPublishStepContentOptions) => {
+  const stickers = await findOrderedPackStickers(db, pack);
+  const allReady = stickers.every(isStickerPublishReady);
+  const currentIndex = stickers.findIndex(sticker => sticker.id === currentStickerId);
+  const targetIndex = direction === 'prev' ? Math.max(0, currentIndex - 1) : currentIndex + 1;
+  if (currentIndex === -1 || targetIndex >= stickers.length) {
+    return getPublishDoneContent(t, pack, allReady);
+  }
+
+  return getPublishStickerContent({
+    t,
+    pack,
+    sticker: stickers[targetIndex],
+    index: targetIndex,
+    total: stickers.length,
+    allReady,
+  });
+};
+
+interface GetPublishJumpToInvalidContentOptions {
+  t: TFunction;
+  db: PrismaClient;
+  pack: PublishPack;
+}
+
+// Jumps straight to the first sticker that's still blocking publish, or the
+// completion text if everything already passes (e.g. a race with another edit)
+export const getPublishJumpToInvalidContent = async ({ t, db, pack }: GetPublishJumpToInvalidContentOptions) => {
+  const stickers = await findOrderedPackStickers(db, pack);
+  const targetIndex = stickers.findIndex(sticker => !isStickerPublishReady(sticker));
+  const allReady = targetIndex === -1;
+  if (allReady) {
+    return getPublishDoneContent(t, pack, allReady);
+  }
+
+  return getPublishStickerContent({
+    t,
+    pack,
+    sticker: stickers[targetIndex],
+    index: targetIndex,
+    total: stickers.length,
+    allReady,
+  });
+};

--- a/src/utils/get-sticker-message-content.ts
+++ b/src/utils/get-sticker-message-content.ts
@@ -1,10 +1,11 @@
 import { ComponentType } from 'discord-api-types/v10';
 import { MessageEditOptions } from 'discord.js';
-import { Sticker, TelegramSticker } from '../generated/prisma/client.js';
+import { Pack, Sticker, TelegramSticker } from '../generated/prisma/client.js';
 import { mapStickersToGalleryItems, StickerGalleryItems } from './map-stickers-to-gallery-items.js';
+import { resolveStickerNsfw } from './resolve-sticker-nsfw.js';
 
 interface GetStickerMessageContentParams {
-  stickers: (Sticker & { telegramSticker?: TelegramSticker | null })[];
+  stickers: (Sticker & { telegramSticker?: TelegramSticker | null, pack: Pick<Pack, 'nsfw'> })[];
 }
 
 export const getStickerMessageContent = ({
@@ -12,7 +13,7 @@ export const getStickerMessageContent = ({
 }: GetStickerMessageContentParams): Pick<MessageEditOptions, 'components'> & {
   files?: StickerGalleryItems['files']
 } => {
-  const { files, items } = mapStickersToGalleryItems(stickers);
+  const { files, items } = mapStickersToGalleryItems(stickers, stickers.map(sticker => resolveStickerNsfw(sticker, sticker.pack)));
 
   return {
     components: [

--- a/src/utils/interactions.ts
+++ b/src/utils/interactions.ts
@@ -15,6 +15,7 @@ import { massRenameStickersCommand } from '../commands/mass-rename-stickers.comm
 import { nsfwPackCommand } from '../commands/nsfw-pack.command.js';
 import { nsfwStickerCommand } from '../commands/nsfw-sticker.command.js';
 import { packCommand } from '../commands/pack.command.js';
+import { publishImportedPackCommand } from '../commands/publish-imported-pack.command.js';
 import { reorderStickerCommand } from '../commands/reorder-sticker.command.js';
 import { stickerCommand } from '../commands/sticker.command.js';
 import { stickerDetailsCommand } from '../commands/sticker-details.command.js';
@@ -27,6 +28,11 @@ import { packPageFirstComponent } from '../components/pack-page-first.component.
 import { packPageLastComponent } from '../components/pack-page-last.component.js';
 import { packPageNextComponent } from '../components/pack-page-next.component.js';
 import { packPagePrevComponent } from '../components/pack-page-prev.component.js';
+import { publishConfirmComponent } from '../components/publish-confirm.component.js';
+import { publishJumpInvalidComponent } from '../components/publish-jump-invalid.component.js';
+import { publishNextComponent } from '../components/publish-next.component.js';
+import { publishOpenComponent } from '../components/publish-open.component.js';
+import { publishPrevComponent } from '../components/publish-prev.component.js';
 import { updateMessageComponent } from '../components/update-message.component.js';
 
 export const chatInputCommandRegistry = createChatInputCommandRegistry([
@@ -43,6 +49,7 @@ export const chatInputCommandRegistry = createChatInputCommandRegistry([
   editPackCommand,
   reorderStickerCommand,
   massRenameStickersCommand,
+  publishImportedPackCommand,
 ]);
 
 export const contextMenuCommandRegistry = createContextMenuCommandRegistry([
@@ -60,6 +67,11 @@ export const componentRegistry = createComponentRegistry([
   massRenameOpenComponent,
   massRenamePrevComponent,
   massRenameNextComponent,
+  publishOpenComponent,
+  publishPrevComponent,
+  publishNextComponent,
+  publishConfirmComponent,
+  publishJumpInvalidComponent,
 ]);
 
 export const modalRegistry = flattenCommandModals(chatInputCommandRegistry);

--- a/src/utils/map-stickers-to-gallery-items.ts
+++ b/src/utils/map-stickers-to-gallery-items.ts
@@ -9,23 +9,26 @@ export interface StickerGalleryItems {
   items: APIMediaGalleryItem[];
 }
 
-export const mapStickersToGalleryItems = (stickers: (Pick<Sticker, 'description'> & StickerUrlSource)[], spoiler = false): StickerGalleryItems => {
-  const { files, galleryStickers } = stickers.reduce((acc, sticker) => {
+export const mapStickersToGalleryItems = (stickers: (Pick<Sticker, 'description'> & StickerUrlSource)[], spoiler: boolean | boolean[] = false): StickerGalleryItems => {
+  const resolveSpoiler = (index: number) => Array.isArray(spoiler) ? spoiler[index] ?? false : spoiler;
+
+  const { files, galleryStickers } = stickers.reduce((acc, sticker, index) => {
     const url = getStickerUrl(sticker);
     const paths = getStickerFilePathFromUrl(url);
+    const stickerSpoiler = resolveSpoiler(index);
     if (paths === null) {
       return {
         ...acc,
-        galleryStickers: [...acc.galleryStickers, { description: sticker.description, url }],
+        galleryStickers: [...acc.galleryStickers, { description: sticker.description, url, spoiler: stickerSpoiler }],
       };
     }
 
     const newFile = new AttachmentBuilder(paths.filePath, {
       name: paths.stickerFileName,
-    }).setSpoiler(spoiler);
+    }).setSpoiler(stickerSpoiler);
     const attachmentUrl = `attachment://${newFile.name}`;
     return {
-      galleryStickers: [...acc.galleryStickers, { description: sticker.description, url: attachmentUrl }],
+      galleryStickers: [...acc.galleryStickers, { description: sticker.description, url: attachmentUrl, spoiler: stickerSpoiler }],
       files: [
         ...acc.files,
         newFile,
@@ -33,7 +36,7 @@ export const mapStickersToGalleryItems = (stickers: (Pick<Sticker, 'description'
     };
   }, {
     files: [] as AttachmentBuilder[],
-    galleryStickers: [] as { description: string | null, url: string }[],
+    galleryStickers: [] as { description: string | null, url: string, spoiler: boolean }[],
   });
 
   return {
@@ -41,7 +44,7 @@ export const mapStickersToGalleryItems = (stickers: (Pick<Sticker, 'description'
     items: galleryStickers.map(sticker => ({
       media: { url: sticker.url },
       description: sticker.description ?? undefined,
-      spoiler,
+      spoiler: sticker.spoiler,
     })),
   };
 };

--- a/src/utils/post-pack-to-feed.ts
+++ b/src/utils/post-pack-to-feed.ts
@@ -1,6 +1,7 @@
 import { time } from '@discordjs/formatters';
 import { MessageFlags } from 'discord-api-types/v10';
 import {
+  ButtonInteraction,
   ChatInputCommandInteraction,
   ModalSubmitInteraction,
   TimestampStyles,
@@ -19,7 +20,7 @@ export interface PackSnapshot {
 
 interface PostPackToFeedParams {
   context: InteractionContext;
-  interaction: ChatInputCommandInteraction | ModalSubmitInteraction;
+  interaction: ChatInputCommandInteraction | ModalSubmitInteraction | ButtonInteraction;
   pack: Pack & { telegramPack?: TelegramPack | null };
   action: 'create' | 'edit' | 'delete';
   snapshot?: PackSnapshot;

--- a/src/utils/post-sticker-to-feed.ts
+++ b/src/utils/post-sticker-to-feed.ts
@@ -16,13 +16,22 @@ import { getPackNsfwEmoji } from './get-pack-nsfw-emoji.js';
 import { getPackVisibilityEmoji } from './get-pack-visibility-emoji.js';
 import { mapStickersToGalleryItems } from './map-stickers-to-gallery-items.js';
 import { recordStickerMessages } from './record-sticker-messages.js';
+import { resolveStickerNsfw } from './resolve-sticker-nsfw.js';
 import { wrapUrlsInAngleBrackets } from './wrap-urls-in-angle-brackets.js';
 
 export interface StickerSnapshot {
   name: string;
   description: string | null;
   url: string | null;
+  nsfwOverride: boolean | null;
 }
+
+const formatRating = (nsfwOverride: boolean | null) => {
+  if (nsfwOverride === null) return 'pack default';
+  return nsfwOverride ? 'NSFW' : 'SFW';
+};
+
+const formatName = (name: string) => name ? `\`${name}\`` : '_(empty)_';
 
 const mapDescription = (description: string | null, prefix: string) => (
   description ? [
@@ -32,8 +41,8 @@ const mapDescription = (description: string | null, prefix: string) => (
     `**${prefix}:** _(empty)_`,
   ]
 );
-const wrapUrlInSpoiler = (userPack: Pick<Pack, 'nsfw'>, url: string) => {
-  return userPack.nsfw ? `||${url}||` : url;
+const wrapUrlInSpoiler = (spoiler: boolean, url: string) => {
+  return spoiler ? `||${url}||` : url;
 };
 
 interface PostStickerToFeedParams {
@@ -59,29 +68,32 @@ export const postStickerToFeed = async ({
 
   const webhookClient = new WebhookClient({ url: env.DISCORD_FEED_WEBHOOK_URL });
   const urlChanged = snapshot && snapshot.url !== sticker.url;
+  const spoiler = resolveStickerNsfw(sticker, userPack);
   const {
     items,
     files,
-  } = mapStickersToGalleryItems(urlChanged ? [snapshot, sticker] : [sticker], userPack.nsfw);
+  } = mapStickersToGalleryItems(urlChanged ? [snapshot, sticker] : [sticker], spoiler);
 
   const nameChanged = snapshot && snapshot.name !== sticker.name;
   const descriptionChanged = snapshot && snapshot.description !== sticker.description;
+  const ratingChanged = snapshot && snapshot.nsfwOverride !== sticker.nsfwOverride;
   const replyMessage = await webhookClient.send({
     flags: MessageFlags.SuppressNotifications,
     content: [
       `# Sticker ${action.replace(/e?$/, 'ed')}`,
-      ...(nameChanged ? [`**Old name:** \`${snapshot.name}\``] : []),
-      `**${nameChanged ? 'New name' : 'Name'}:** \`${getFormattedStickerName(sticker)}\` (\`${sticker.id}\`)`,
+      ...(nameChanged ? [`**Old name:** ${formatName(snapshot.name)}`] : []),
+      `**${nameChanged ? 'New name' : 'Name'}:** ${formatName(getFormattedStickerName(sticker))} (\`${sticker.id}\`)`,
       ...(descriptionChanged ? mapDescription(snapshot.description, 'Old description') : []),
       ...(mapDescription(sticker.description, descriptionChanged ? 'New description' : 'Description')),
+      `**Rating:** \`${formatRating(sticker.nsfwOverride)}\`${ratingChanged ? ` (was \`${formatRating(snapshot.nsfwOverride)}\`)` : ''}`,
       `**Created at:** ${time(sticker.createdAt, TimestampStyles.FullDateShortTime)} (${time(sticker.createdAt, TimestampStyles.RelativeTime)})`,
       ...(sticker.updatedAt ? [`**Updated at:** ${time(sticker.updatedAt, TimestampStyles.FullDateShortTime)} (${time(sticker.updatedAt, TimestampStyles.RelativeTime)})`] : []),
       ...(sticker.deletedAt ? [`**Deleted at:** ${time(sticker.deletedAt, TimestampStyles.FullDateShortTime)} (${time(sticker.deletedAt, TimestampStyles.RelativeTime)})`] : []),
       `**Created by:** ${userMention(interaction.user.id)} (\`${interaction.user.id}\`)`,
       ...(sticker.deletedBy ? [`**Deleted by:** ${userMention(String(sticker.deletedBy))} (\`${sticker.deletedBy}\`)`] : []),
       `**Pack:** \`${wrapUrlsInAngleBrackets(userPack.telegramPack?.title ?? userPack.name)}\` (\`${userPack.id}\`) ${getPackVisibilityEmoji(userPack)}${getPackNsfwEmoji(userPack)}`,
-      ...(urlChanged ? [`**Old URL:** ${snapshot.url ? wrapUrlInSpoiler(userPack, snapshot.url) : '_(none)_'}`, `**New URL:** \`${getStickerUrl(sticker)}\``] : []),
-      `**Image:** ${items.filter(item => !item.media.url.startsWith('attachment://')).map(item => wrapUrlInSpoiler(userPack, item.media.url)).join(' ')}`,
+      ...(urlChanged ? [`**Old URL:** ${snapshot.url ? wrapUrlInSpoiler(spoiler, snapshot.url) : '_(none)_'}`, `**New URL:** \`${getStickerUrl(sticker)}\``] : []),
+      `**Image:** ${items.filter(item => !item.media.url.startsWith('attachment://')).map(item => wrapUrlInSpoiler(spoiler, item.media.url)).join(' ')}`,
     ].join('\n'),
     files,
   });

--- a/src/utils/resolve-sticker-nsfw.ts
+++ b/src/utils/resolve-sticker-nsfw.ts
@@ -1,0 +1,6 @@
+import { Pack, Sticker } from '../generated/prisma/client.js';
+
+// A sticker's own rating override takes precedence over its pack's default rating
+export const resolveStickerNsfw = (sticker: Pick<Sticker, 'nsfwOverride'>, pack: Pick<Pack, 'nsfw'>) => (
+  sticker.nsfwOverride ?? pack.nsfw
+);


### PR DESCRIPTION
## Summary
- Adds `/publish-imported-pack`, which walks the owner of an imported Telegram pack copy through every sticker (mirroring `/mass-rename-stickers`'s step UI) and lets them publish it as the canonical public copy once every sticker has a real name and an explicit SFW/NSFW rating. A "jump to first invalid sticker" button helps find what's still blocking publish.
- Only one pack per Telegram pack can be public at a time (enforced with a DB partial unique index + server-side re-validation on confirm). The pack's own SFW/NSFW flag is derived at publish time from its stickers' ratings (NSFW only if *every* sticker is NSFW).
- `/edit-pack` can now unpublish an already-published imported pack again (previously it silently forced `public` back to `false` on every edit — a latent bug fixed here), ready for re-publishing whenever the owner wants.
- Adds a per-sticker `nsfwOverride` rating (pack default/SFW/NSFW), editable via `/edit-sticker`, so a single sticker can be forced NSFW or SFW independent of its pack (partially implements #82). Blur behavior and NSFW-command filtering in `/pack`, `/sticker`, pagination, and the feed webhook now resolve per sticker instead of trusting only the whole-pack flag.
- New imports (and new stickers added to an already-imported pack) seed their name/rating from the published pack instead of starting blank, so the publisher's version becomes the default for everyone importing fresh — existing users' own copies are never touched.
- Fixes a feed webhook rendering bug where an empty "old name" broke the message's markdown; now falls back to `_(empty)_` like descriptions already do.

Closes #91.

## Test plan
- [ ] `npx prisma migrate deploy` applies cleanly against a copy of prod data
- [ ] Import the same Telegram pack as two users; run `/publish-imported-pack` as one, confirm the Publish button stays disabled until every sticker has a name + explicit rating, then publish
- [ ] Confirm the other user gets an "already published by X" error when trying to publish their own copy of the same Telegram pack
- [ ] A third user importing the pack fresh gets the published names/ratings as defaults
- [ ] Mark a sticker NSFW inside an SFW pack via `/edit-sticker`; confirm it's blurred everywhere and excluded from `/pack`/`/sticker` but visible via `/nsfw-pack`/`/nsfw-sticker`
- [ ] `/edit-pack` on a published pack can flip it back to private, and `/publish-imported-pack` works again afterward